### PR TITLE
feat(ws-client): respond with pong to ping messages

### DIFF
--- a/lighter/ws_client.py
+++ b/lighter/ws_client.py
@@ -3,7 +3,6 @@ from websockets.sync.client import connect
 from websockets.client import connect as connect_async
 from lighter.configuration import Configuration
 
-
 class WsClient:
     def __init__(
         self,
@@ -51,6 +50,9 @@ class WsClient:
             self.handle_subscribed_account(message)
         elif message_type == "update/account_all":
             self.handle_update_account(message)
+        elif message_type == "ping":
+            # Respond to ping with pong
+            ws.send(json.dumps({"type": "pong"}))
         else:
             self.handle_unhandled_message(message)
 
@@ -60,6 +62,9 @@ class WsClient:
 
         if message_type == "connected":
             await self.handle_connected_async(ws)
+        elif message_type == "ping":
+            # Respond to ping with pong
+            await ws.send(json.dumps({"type": "pong"}))
         else:
             self.on_message(ws, message)
 


### PR DESCRIPTION
- Update WsClient to automatically send a "pong" message in response to any received "ping" message, for both sync and async websocket usage.
- Adds ping detection in on_message and on_message_async.
- Sends back a {"type": "pong"} payload.
- No breaking changes; existing subscriptions and message flows are unaffected.