### PR TITLE
expecting None response on @process_api_key_and_nonce

### DIFF
--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -93,7 +93,7 @@ def process_api_key_and_nonce(func):
         ret: TxHash
         try:
             created_tx, ret, err = await func(self, *args, **kwargs, nonce=nonce, api_key_index=api_key_index)
-            if ret.code != CODE_OK:
+            if (ret is None and err) or (ret and ret.code != CODE_OK):
                 self.nonce_manager.acknowledge_failure(api_key_index)
         except lighter.exceptions.BadRequestException as e:
             if "invalid nonce" in str(e):


### PR DESCRIPTION
`ret` can be None for any errors. for example with error «TriggerPrice is invalid» on creating order
now when `ret` is None, `ret.code` is undefined and raising `'NoneType' object has no attribute 'code'`