### PR TITLE
Remove global logging.basicConfig() call

### DIFF
--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -19,7 +19,6 @@ from lighter import nonce_manager
 from lighter.models.resp_send_tx import RespSendTx
 from lighter.transactions import CreateOrder, CancelOrder, Withdraw
 
-logging.basicConfig(level=logging.DEBUG)
 
 CODE_OK = 200
 


### PR DESCRIPTION
Just a small change — removed the global logging.basicConfig call so users can control logging themselves