### PR TITLE
1 liner fix on openapi.json format

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -4374,7 +4374,7 @@
           "enum": [
             "inactive",
             "frozen",
-            "active",
+            "active"
           ]
         },
         "taker_fee": {


### PR DESCRIPTION
A liner json format fix

```
jq . openapi.json > /dev/null
jq: parse error: Expected another array element at line 4378, column 11
```