### PR TITLE
fix type error for reduce only in examples

### DIFF
--- a/examples/create_cancel_order.py
+++ b/examples/create_cancel_order.py
@@ -41,7 +41,7 @@ async def main():
         is_ask=True,
         order_type=lighter.SignerClient.ORDER_TYPE_LIMIT,
         time_in_force=lighter.SignerClient.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
-        reduce_only=0,
+        reduce_only=False,
         trigger_price=0,
     )
     print(f"Create Order {tx=} {tx_hash=} {err=}")

--- a/examples/create_with_multiple_keys.py
+++ b/examples/create_with_multiple_keys.py
@@ -36,7 +36,7 @@ async def main():
             is_ask=True,
             order_type=lighter.SignerClient.ORDER_TYPE_LIMIT,
             time_in_force=lighter.SignerClient.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
-            reduce_only=0,
+            reduce_only=False,
             trigger_price=0,
         )
         print(res_tuple)


### PR DESCRIPTION
The change intends to resolve type errors in the examples for the `reduce_only` argument.
While a numeric value is used by the underlying linked library, the SDK exposes the possible values correctly as a boolean. The numeric values which I'm updating here where likely missed in earlier changes when the bool was introduced. 
The update should make it consistent with the rest of the code base. 

TLDR - simply resolves a type complaint:

<img width="1619" height="695" alt="Screenshot_20251016_104556" src="https://github.com/user-attachments/assets/79e5b143-6c05-44fd-b6c2-34e7f1a3b39d" />
