### PR TITLE
use constant for default expiry value

### DIFF
--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -566,7 +566,7 @@ class SignerClient:
         time_in_force,
         reduce_only=False,
         trigger_price=NIL_TRIGGER_PRICE,
-        order_expiry=-1,
+        order_expiry=DEFAULT_28_DAY_ORDER_EXPIRY,
         nonce=-1,
         api_key_index=-1,
     ) -> (CreateOrder, TxHash, str):


### PR DESCRIPTION
The PR makes use of the helper constant for the default expiry value. Makes it consistent with the rest of the code base.