### PR TITLE
Fix: Update deprecated /candlesticks endpoint to /candles

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Class | Method | HTTP request | Description
 *BlockApi* | [**block**](docs/BlockApi.md#block) | **GET** /api/v1/block | block
 *BlockApi* | [**blocks**](docs/BlockApi.md#blocks) | **GET** /api/v1/blocks | blocks
 *BlockApi* | [**current_height**](docs/BlockApi.md#current_height) | **GET** /api/v1/currentHeight | currentHeight
-*CandlestickApi* | [**candlesticks**](docs/CandlestickApi.md#candlesticks) | **GET** /api/v1/candlesticks | candlesticks
+*CandlestickApi* | [**candlesticks**](docs/CandlestickApi.md#candlesticks) | **GET** /api/v1/candles | candlesticks
 *CandlestickApi* | [**fundings**](docs/CandlestickApi.md#fundings) | **GET** /api/v1/fundings | fundings
 *OrderApi* | [**account_inactive_orders**](docs/OrderApi.md#account_inactive_orders) | **GET** /api/v1/accountInactiveOrders | accountInactiveOrders
 *OrderApi* | [**exchange_stats**](docs/OrderApi.md#exchange_stats) | **GET** /api/v1/exchangeStats | exchangeStats

--- a/docs/CandlestickApi.md
+++ b/docs/CandlestickApi.md
@@ -4,7 +4,7 @@ All URIs are relative to *https://mainnet.zklighter.elliot.ai*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**candlesticks**](CandlestickApi.md#candlesticks) | **GET** /api/v1/candlesticks | candlesticks
+[**candlesticks**](CandlestickApi.md#candlesticks) | **GET** /api/v1/candles | candlesticks
 [**fundings**](CandlestickApi.md#fundings) | **GET** /api/v1/fundings | fundings
 
 

--- a/lighter/api/candlestick_api.py
+++ b/lighter/api/candlestick_api.py
@@ -372,7 +372,7 @@ class CandlestickApi:
 
         return self.api_client.param_serialize(
             method='GET',
-            resource_path='/api/v1/candlesticks',
+            resource_path='/api/v1/candles',
             path_params=_path_params,
             query_params=_query_params,
             header_params=_header_params,

--- a/openapi.json
+++ b/openapi.json
@@ -773,7 +773,7 @@
         "description": "Get if next bridge is fast"
       }
     },
-    "/api/v1/candlesticks": {
+    "/api/v1/candles": {
       "get": {
         "summary": "candlesticks",
         "operationId": "candlesticks",


### PR DESCRIPTION
## Summary
Updates the deprecated `/api/v1/candlesticks` endpoint to the current `/api/v1/candles` endpoint.

## Background
The Lighter API deprecated the `/api/v1/candlesticks` endpoint, causing all SDK candlestick downloads to fail with HTTP 403 Forbidden errors.

## Evidence

**Old endpoint (deprecated):**
- URL: `https://mainnet.zklighter.elliot.ai/api/v1/candlesticks`
- Status: Returns **HTTP 403 Forbidden** ❌
- Docs: https://apidocs.lighter.xyz/reference/candlesticks → **404 Not Found** ❌

**New endpoint (current):**
- URL: `https://mainnet.zklighter.elliot.ai/api/v1/candles`
- Status: Returns **HTTP 200 OK** ✅
- Docs: https://apidocs.lighter.xyz/reference/candles → **Active** ✅

**Verification:**
```bash
# Old endpoint fails
curl -I "https://mainnet.zklighter.elliot.ai/api/v1/candlesticks?market_id=1&resolution=1h&count_back=1"
# HTTP/2 403

# New endpoint works
curl -I "https://mainnet.zklighter.elliot.ai/api/v1/candles?market_id=1&resolution=1h&count_back=1"
# HTTP/2 200
```

## Changes
- ✅ Updated OpenAPI specification (`openapi.json`): `/api/v1/candlesticks` → `/api/v1/candles`
- ✅ Updated endpoint in `lighter/api/candlestick_api.py`
- ✅ Updated API reference in `README.md`
- ✅ Updated documentation in `docs/CandlestickApi.md`

## Testing
Manually verified endpoints:
- ❌ `/api/v1/candlesticks` returns 403
- ✅ `/api/v1/candles` returns 200

## Impact
This fix resolves HTTP 403 errors for all users attempting to download candlestick data via the SDK. No breaking changes to the Python API - the method names and signatures remain unchanged.

## Note for Maintainers
This SDK appears to be auto-generated from OpenAPI spec. If you regenerate from a source spec file, please ensure the source spec is also updated to use `/api/v1/candles`.

## References
- Current API Docs: https://apidocs.lighter.xyz/reference/candles
- Lighter API Documentation: https://apidocs.lighter.xyz