### PR TITLE
Added aarch64 support

### DIFF
--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -64,7 +64,7 @@ def __get_shared_library():
     is_mac = platform.system() == "Darwin"
     is_windows = platform.system() == "Windows"
     is_x64 = platform.machine().lower() in ("amd64", "x86_64")
-    is_arm = platform.machine().lower() == "arm64"
+    is_arm = platform.machine().lower() in ("arm64", "aarch64")
 
     current_file_directory = os.path.dirname(os.path.abspath(__file__))
     path_to_signer_folders = os.path.join(current_file_directory, "signers")


### PR DESCRIPTION
Implements fix of https://github.com/elliottech/lighter-python/issues/89

Raspberry Pi 4B returns "aarch64" instead of "arm64", and wouldn't proceed on loading the Linux arm shared library.

Tested on `Linux raspberrypi 6.12.47+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.12.47-1+rpt1 (2025-09-16) aarch64` (fresh Raspberry Pi OS Lite image + git + direnv)