### PR TITLE
Add missing stake/unstake transfer types

### DIFF
--- a/lighter/models/transfer_history_item.py
+++ b/lighter/models/transfer_history_item.py
@@ -45,8 +45,8 @@ class TransferHistoryItem(BaseModel):
     @field_validator('type')
     def type_validate_enum(cls, value):
         """Validates the enum"""
-        if value not in set(['L2TransferInflow', 'L2TransferOutflow', 'L2BurnSharesInflow', 'L2BurnSharesOutflow', 'L2MintSharesInflow', 'L2MintSharesOutflow', 'L2SelfTransfer']):
-            raise ValueError("must be one of enum values ('L2TransferInflow', 'L2TransferOutflow', 'L2BurnSharesInflow', 'L2BurnSharesOutflow', 'L2MintSharesInflow', 'L2MintSharesOutflow', 'L2SelfTransfer')")
+        if value not in set(['L2TransferInflow', 'L2TransferOutflow', 'L2BurnSharesInflow', 'L2BurnSharesOutflow', 'L2MintSharesInflow', 'L2MintSharesOutflow', 'L2SelfTransfer', 'L2StakeAssetInflow', 'L2StakeAssetOutflow', 'L2UnstakeAssetInflow']):
+            raise ValueError("must be one of enum values ('L2TransferInflow', 'L2TransferOutflow', 'L2BurnSharesInflow', 'L2BurnSharesOutflow', 'L2MintSharesInflow', 'L2MintSharesOutflow', 'L2SelfTransfer', 'L2StakeAssetInflow', 'L2StakeAssetOutflow', 'L2UnstakeAssetInflow')")
         return value
 
     @field_validator('from_route')


### PR DESCRIPTION
Add **L2StakeAssetInflow**, **L2StakeAssetOutflow**, and **L2UnstakeAssetInflow** transfer types to the enum validator.

**L2UnstakeAssetOutflow** might also exist, but I don't have it in my transfer history to confirm.