### PR TITLE
Feat/python sdk hardening issue fixes

### DIFF
--- a/lighter/__init__.py
+++ b/lighter/__init__.py
@@ -14,7 +14,12 @@
 """  # noqa: E501
 
 
-__version__ = "1.0.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("lighter-sdk")
+except PackageNotFoundError:
+    __version__ = "0+unknown"
 
 # import apis into sdk package
 from lighter.api.account_api import AccountApi

--- a/lighter/api/account_api.py
+++ b/lighter/api/account_api.py
@@ -55,6 +55,13 @@ class AccountApi:
             api_client = ApiClient.get_default()
         self.api_client = api_client
 
+    @staticmethod
+    def _normalize_l1_address(l1_address: str) -> str:
+        normalized = l1_address.strip()
+        if normalized and not normalized.startswith(("0x", "0X")):
+            normalized = f"0x{normalized}"
+        return normalized
+
 
     async def account(
         self,
@@ -102,6 +109,9 @@ class AccountApi:
         :type _host_index: int, optional
         :return: Returns the result object.
         """ # noqa: E501
+
+        if by in ("l1_address", "l1Address"):
+            value = self._normalize_l1_address(value)
 
         _param = self._account_serialize(
             by=by,
@@ -174,6 +184,9 @@ class AccountApi:
         :return: Returns the result object.
         """ # noqa: E501
 
+        if by in ("l1_address", "l1Address"):
+            value = self._normalize_l1_address(value)
+
         _param = self._account_serialize(
             by=by,
             value=value,
@@ -244,6 +257,9 @@ class AccountApi:
         :type _host_index: int, optional
         :return: Returns the result object.
         """ # noqa: E501
+
+        if by in ("l1_address", "l1Address"):
+            value = self._normalize_l1_address(value)
 
         _param = self._account_serialize(
             by=by,
@@ -980,6 +996,8 @@ class AccountApi:
         :return: Returns the result object.
         """ # noqa: E501
 
+        l1_address = self._normalize_l1_address(l1_address)
+
         _param = self._accounts_by_l1_address_serialize(
             l1_address=l1_address,
             _request_auth=_request_auth,
@@ -1047,6 +1065,8 @@ class AccountApi:
         :return: Returns the result object.
         """ # noqa: E501
 
+        l1_address = self._normalize_l1_address(l1_address)
+
         _param = self._accounts_by_l1_address_serialize(
             l1_address=l1_address,
             _request_auth=_request_auth,
@@ -1113,6 +1133,8 @@ class AccountApi:
         :type _host_index: int, optional
         :return: Returns the result object.
         """ # noqa: E501
+
+        l1_address = self._normalize_l1_address(l1_address)
 
         _param = self._accounts_by_l1_address_serialize(
             l1_address=l1_address,

--- a/lighter/api/order_api.py
+++ b/lighter/api/order_api.py
@@ -32,6 +32,7 @@ from lighter.models.trades import Trades
 
 from lighter.api_client import ApiClient, RequestSerialized
 from lighter.api_response import ApiResponse
+from lighter.exceptions import ApiValueError
 from lighter.rest import RESTResponseType
 
 

--- a/lighter/api/order_api.py
+++ b/lighter/api/order_api.py
@@ -51,7 +51,7 @@ class OrderApi:
     async def account_active_orders(
         self,
         account_index: StrictInt,
-        market_id: Optional[StrictInt] = None,
+        market_id: StrictInt,
         authorization: Annotated[Optional[StrictStr], Field(description=" make required after integ is done")] = None,
         auth: Annotated[Optional[StrictStr], Field(description=" made optional to support header auth clients")] = None,
         _request_timeout: Union[
@@ -130,7 +130,7 @@ class OrderApi:
     async def account_active_orders_with_http_info(
         self,
         account_index: StrictInt,
-        market_id: Optional[StrictInt] = None,
+        market_id: StrictInt,
         authorization: Annotated[Optional[StrictStr], Field(description=" make required after integ is done")] = None,
         auth: Annotated[Optional[StrictStr], Field(description=" made optional to support header auth clients")] = None,
         _request_timeout: Union[
@@ -209,7 +209,7 @@ class OrderApi:
     async def account_active_orders_without_preload_content(
         self,
         account_index: StrictInt,
-        market_id: Optional[StrictInt] = None,
+        market_id: StrictInt,
         authorization: Annotated[Optional[StrictStr], Field(description=" make required after integ is done")] = None,
         auth: Annotated[Optional[StrictStr], Field(description=" made optional to support header auth clients")] = None,
         _request_timeout: Union[
@@ -319,9 +319,9 @@ class OrderApi:
             
             _query_params.append(('account_index', account_index))
             
-        if market_id is not None:
-            
-            _query_params.append(('market_id', market_id))
+        if market_id is None:
+            raise ApiValueError("Missing the required parameter `market_id` when calling `account_active_orders`")
+        _query_params.append(('market_id', market_id))
             
         # process the header parameters
         # process the form parameters

--- a/lighter/api/order_api.py
+++ b/lighter/api/order_api.py
@@ -51,7 +51,7 @@ class OrderApi:
     async def account_active_orders(
         self,
         account_index: StrictInt,
-        market_id: StrictInt,
+        market_id: Optional[StrictInt] = None,
         authorization: Annotated[Optional[StrictStr], Field(description=" make required after integ is done")] = None,
         auth: Annotated[Optional[StrictStr], Field(description=" made optional to support header auth clients")] = None,
         _request_timeout: Union[
@@ -130,7 +130,7 @@ class OrderApi:
     async def account_active_orders_with_http_info(
         self,
         account_index: StrictInt,
-        market_id: StrictInt,
+        market_id: Optional[StrictInt] = None,
         authorization: Annotated[Optional[StrictStr], Field(description=" make required after integ is done")] = None,
         auth: Annotated[Optional[StrictStr], Field(description=" made optional to support header auth clients")] = None,
         _request_timeout: Union[
@@ -209,7 +209,7 @@ class OrderApi:
     async def account_active_orders_without_preload_content(
         self,
         account_index: StrictInt,
-        market_id: StrictInt,
+        market_id: Optional[StrictInt] = None,
         authorization: Annotated[Optional[StrictStr], Field(description=" make required after integ is done")] = None,
         auth: Annotated[Optional[StrictStr], Field(description=" made optional to support header auth clients")] = None,
         _request_timeout: Union[
@@ -3774,8 +3774,9 @@ class OrderApi:
             
             _query_params.append(('limit', limit))
             
-        if aggregate is not None:
-            
+        if aggregate is None:
+            _query_params.append(('aggregate', False))
+        else:
             _query_params.append(('aggregate', aggregate))
             
         # process the header parameters

--- a/lighter/models/account_position.py
+++ b/lighter/models/account_position.py
@@ -41,10 +41,11 @@ class AccountPosition(BaseModel):
     liquidation_price: StrictStr
     total_funding_paid_out: Optional[StrictStr] = None
     margin_mode: StrictInt
+    leverage: Optional[StrictInt] = None
     allocated_margin: StrictStr
     total_discount: StrictStr
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["market_id", "symbol", "initial_margin_fraction", "open_order_count", "pending_order_count", "position_tied_order_count", "sign", "position", "avg_entry_price", "position_value", "unrealized_pnl", "realized_pnl", "liquidation_price", "total_funding_paid_out", "margin_mode", "allocated_margin", "total_discount"]
+    __properties: ClassVar[List[str]] = ["market_id", "symbol", "initial_margin_fraction", "open_order_count", "pending_order_count", "position_tied_order_count", "sign", "position", "avg_entry_price", "position_value", "unrealized_pnl", "realized_pnl", "liquidation_price", "total_funding_paid_out", "margin_mode", "leverage", "allocated_margin", "total_discount"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -119,6 +120,7 @@ class AccountPosition(BaseModel):
             "liquidation_price": obj.get("liquidation_price"),
             "total_funding_paid_out": obj.get("total_funding_paid_out"),
             "margin_mode": obj.get("margin_mode"),
+            "leverage": obj.get("leverage"),
             "allocated_margin": obj.get("allocated_margin"),
             "total_discount": obj.get("total_discount")
         })

--- a/lighter/models/candle.py
+++ b/lighter/models/candle.py
@@ -31,15 +31,10 @@ class Candle(BaseModel):
     h: Union[StrictFloat, StrictInt] = Field(description=" high")
     l: Union[StrictFloat, StrictInt] = Field(description=" low")
     c: Union[StrictFloat, StrictInt] = Field(description=" close")
-    o: Union[StrictFloat, StrictInt] = Field(description=" open_raw", alias="O")
-    h: Union[StrictFloat, StrictInt] = Field(description=" high_raw", alias="H")
-    l: Union[StrictFloat, StrictInt] = Field(description=" low_raw", alias="L")
-    c: Union[StrictFloat, StrictInt] = Field(description=" close_raw", alias="C")
     v: Union[StrictFloat, StrictInt] = Field(description=" volume0")
-    v: Union[StrictFloat, StrictInt] = Field(description=" volume1", alias="V")
     i: StrictInt = Field(description=" last_trade_id")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["t", "o", "h", "l", "c", "O", "H", "L", "C", "v", "V", "i"]
+    __properties: ClassVar[List[str]] = ["t", "o", "h", "l", "c", "v", "i"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -104,12 +99,7 @@ class Candle(BaseModel):
             "h": obj.get("h"),
             "l": obj.get("l"),
             "c": obj.get("c"),
-            "O": obj.get("O"),
-            "H": obj.get("H"),
-            "L": obj.get("L"),
-            "C": obj.get("C"),
             "v": obj.get("v"),
-            "V": obj.get("V"),
             "i": obj.get("i")
         })
         # store additional fields in additional_properties

--- a/lighter/models/trade.py
+++ b/lighter/models/trade.py
@@ -45,12 +45,12 @@ class Trade(BaseModel):
     taker_fee: StrictInt
     taker_position_size_before: StrictStr
     taker_entry_quote_before: StrictStr
-    taker_initial_margin_fraction_before: StrictInt
+    taker_initial_margin_fraction_before: Optional[StrictInt] = None
     taker_position_sign_changed: StrictBool
     maker_fee: StrictInt
     maker_position_size_before: StrictStr
     maker_entry_quote_before: StrictStr
-    maker_initial_margin_fraction_before: StrictInt
+    maker_initial_margin_fraction_before: Optional[StrictInt] = None
     maker_position_sign_changed: StrictBool
     transaction_time: StrictInt
     ask_account_pnl: StrictStr

--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -1,4 +1,5 @@
 import ctypes
+import asyncio
 from fractions import Fraction
 from functools import wraps
 import inspect
@@ -6,6 +7,9 @@ import json
 import platform
 import logging
 import os
+import shutil
+import tempfile
+import threading
 import time
 from typing import Dict, List, Optional, Union, Tuple, Any
 
@@ -60,7 +64,7 @@ class SignedTxResponse(ctypes.Structure):
 __signer = None
 
 
-def __get_shared_library():
+def __get_shared_library_path() -> str:
     is_linux = platform.system() == "Linux"
     is_mac = platform.system() == "Darwin"
     is_windows = platform.system() == "Windows"
@@ -71,18 +75,33 @@ def __get_shared_library():
     path_to_signer_folders = os.path.join(current_file_directory, "signers")
 
     if is_arm and is_mac:
-        return ctypes.CDLL(os.path.join(path_to_signer_folders, "lighter-signer-darwin-arm64.dylib"))
+        return os.path.join(path_to_signer_folders, "lighter-signer-darwin-arm64.dylib")
     elif is_linux and is_x64:
-        return ctypes.CDLL(os.path.join(path_to_signer_folders, "lighter-signer-linux-amd64.so"))
+        return os.path.join(path_to_signer_folders, "lighter-signer-linux-amd64.so")
     elif is_linux and is_arm:
-        return ctypes.CDLL(os.path.join(path_to_signer_folders, "lighter-signer-linux-arm64.so"))
+        return os.path.join(path_to_signer_folders, "lighter-signer-linux-arm64.so")
     elif is_windows and is_x64:
-        return ctypes.CDLL(os.path.join(path_to_signer_folders, "lighter-signer-windows-amd64.dll"))
+        return os.path.join(path_to_signer_folders, "lighter-signer-windows-amd64.dll")
     else:
         raise Exception(
             f"Unsupported platform/architecture: {platform.system()}/{platform.machine()}. "
             "Currently supported: Linux(x86_64), macOS(arm64), and Windows(x86_64)."
         )
+
+
+def __get_shared_library(isolated: bool = False):
+    library_path = __get_shared_library_path()
+    temp_dir = None
+
+    if isolated:
+        temp_dir = tempfile.mkdtemp(prefix="lighter-signer-")
+        isolated_library_path = os.path.join(temp_dir, os.path.basename(library_path))
+        shutil.copy2(library_path, isolated_library_path)
+        library_path = isolated_library_path
+
+    signer = ctypes.CDLL(library_path)
+    __populate_shared_library_functions(signer)
+    return signer, temp_dir
 
 
 def decode_and_free(ptr: Any) -> Optional[str]:
@@ -124,7 +143,7 @@ def __populate_shared_library_functions(signer):
     signer.SignCancelOrder.argtypes = [ctypes.c_int, ctypes.c_longlong, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
     signer.SignCancelOrder.restype = SignedTxResponse
 
-    signer.SignWithdraw.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_longlong, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
+    signer.SignWithdraw.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_ulonglong, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
     signer.SignWithdraw.restype = SignedTxResponse
 
     signer.SignCreateSubAccount.argtypes = [ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
@@ -136,7 +155,7 @@ def __populate_shared_library_functions(signer):
     signer.SignModifyOrder.argtypes = [ctypes.c_int, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_int, ctypes.c_int, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
     signer.SignModifyOrder.restype = SignedTxResponse
 
-    signer.SignTransfer.argtypes = [ctypes.c_longlong, ctypes.c_int16, ctypes.c_int8, ctypes.c_int8, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_char_p, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
+    signer.SignTransfer.argtypes = [ctypes.c_longlong, ctypes.c_int16, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_char_p, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
     signer.SignTransfer.restype = SignedTxResponse
 
     signer.SignCreatePublicPool.argtypes = [ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
@@ -176,20 +195,23 @@ def __populate_shared_library_functions(signer):
     signer.Free.restype = None
 
 
-def get_signer():
+def get_signer(*, isolated: bool = False):
+    if isolated:
+        return __get_shared_library(isolated=True)
+
     # check if singleton exists already
     global __signer
     if __signer is not None:
-        return __signer
+        return __signer, None
 
     # create shared library & populate methods
-    __signer = __get_shared_library()
-    __populate_shared_library_functions(__signer)
-    return __signer
+    __signer, _ = __get_shared_library()
+    return __signer, None
 
 
 def create_api_key():
-    result = lighter.signer_client.get_signer().GenerateAPIKey()
+    signer, _ = lighter.signer_client.get_signer()
+    result = signer.GenerateAPIKey()
     private_key_str = decode_and_free(result.privateKey)
     public_key_str = decode_and_free(result.publicKey)
     error = decode_and_free(result.err)
@@ -238,9 +260,23 @@ def process_api_key_and_nonce(func):
 class SignerClient:
     DEFAULT_NONCE = -1
     DEFAULT_API_KEY_INDEX = 255
-    
+
     SKIP_NONCE_OFF = 0
     SKIP_NONCE_ON = 1
+    RESERVED_FRONTEND_API_KEY_INDICES = {0, 1, 2, 3}
+    MAX_CLIENT_ORDER_INDEX = 281_474_976_710_655
+    CLIENT_ORDER_INDEX_BASE_EPOCH_MS = 1_704_067_200_000  # 2024-01-01T00:00:00Z
+    CLIENT_ORDER_INDEX_COUNTER_MOD = 1000
+
+    @staticmethod
+    def _infer_chain_id(url: str) -> int:
+        lowered = url.lower()
+        if "mainnet" in lowered or "api.zklighter.elliot.ai" in lowered:
+            return 304
+        if "testnet" in lowered:
+            return 300
+        logging.warning("Could not infer chain_id from URL '%s'. Defaulting to testnet chain_id=300.", url)
+        return 300
 
     ETH_TICKER_SCALE = 1e8
     USDC_TICKER_SCALE = 1e6
@@ -271,6 +307,7 @@ class SignerClient:
     DEFAULT_28_DAY_ORDER_EXPIRY = -1
     DEFAULT_IOC_EXPIRY = 0
     DEFAULT_10_MIN_AUTH_EXPIRY = -1
+    MIN_ORDER_EXPIRY_BUFFER_MS = 5 * 60 * 1000
     MINUTE = 60
 
     CROSS_MARGIN_MODE = 0
@@ -311,18 +348,27 @@ class SignerClient:
             url,
             account_index,
             api_private_keys: Dict[int, str],
+            chain_id: Optional[int] = None,
             nonce_management_type=nonce_manager.NonceManagerType.OPTIMISTIC,
+            proxy: Optional[str] = None,
+            proxy_headers: Optional[Dict[str, str]] = None,
     ):
         self.url = url
-        self.chain_id = 304 if ("mainnet" in url or "api" in url) else 300
+        self.chain_id = chain_id if chain_id is not None else self._infer_chain_id(url)
 
         self.validate_api_private_keys(api_private_keys)
         self.api_key_dict = api_private_keys
         self.account_index = account_index
-        self.signer = get_signer()
-        self.api_client = lighter.ApiClient(configuration=Configuration(host=url))
+        self.signer, self._signer_temp_dir = get_signer(isolated=True)
+        configuration = Configuration(host=url)
+        if proxy is not None:
+            configuration.proxy = proxy
+        if proxy_headers is not None:
+            configuration.proxy_headers = proxy_headers
+        self.api_client = lighter.ApiClient(configuration=configuration)
         self.tx_api = lighter.TransactionApi(self.api_client)
         self.order_api = lighter.OrderApi(self.api_client)
+        self.account_api = lighter.AccountApi(self.api_client)
 
         self.nonce_manager = nonce_manager.nonce_manager_factory(
             nonce_manager_type=nonce_management_type,
@@ -330,6 +376,10 @@ class SignerClient:
             api_client=self.api_client,
             api_keys_list=list(api_private_keys.keys()),
         )
+        self._warned_reserved_api_key_indexes = set()
+        self._client_order_index_lock = threading.Lock()
+        self._client_order_index_last_epoch_ms = -1
+        self._client_order_index_counter = 0
         for api_key_index in api_private_keys.keys():
             self.create_client(api_key_index)
 
@@ -376,7 +426,16 @@ class SignerClient:
             if private_key.startswith("0x"):
                 private_keys[api_key_index] = private_key[2:]
 
+    def _warn_if_reserved_api_key_index(self, api_key_index: int):
+        if api_key_index in self.RESERVED_FRONTEND_API_KEY_INDICES and api_key_index not in self._warned_reserved_api_key_indexes:
+            logging.warning(
+                "api_key_index %s is reserved by frontend/mobile. Use an index in the 4-254 range for programmatic trading.",
+                api_key_index,
+            )
+            self._warned_reserved_api_key_indexes.add(api_key_index)
+
     def create_client(self, api_key_index):
+        self._warn_if_reserved_api_key_index(api_key_index)
         err_ptr = self.signer.CreateClient(
             self.url.encode('utf-8'),
             self.api_key_dict[api_key_index].encode('utf-8'),
@@ -419,6 +478,23 @@ class SignerClient:
                 raise Exception("ambiguous api key")
         return self.nonce_manager.next_nonce()
 
+    def next_client_order_index(self) -> int:
+        with self._client_order_index_lock:
+            current_epoch_ms = int(time.time() * 1000) - self.CLIENT_ORDER_INDEX_BASE_EPOCH_MS
+            if current_epoch_ms < 0:
+                current_epoch_ms = 0
+
+            if current_epoch_ms == self._client_order_index_last_epoch_ms:
+                self._client_order_index_counter = (self._client_order_index_counter + 1) % self.CLIENT_ORDER_INDEX_COUNTER_MOD
+            else:
+                self._client_order_index_last_epoch_ms = current_epoch_ms
+                self._client_order_index_counter = 0
+
+            client_order_index = current_epoch_ms * self.CLIENT_ORDER_INDEX_COUNTER_MOD + self._client_order_index_counter
+            if client_order_index > self.MAX_CLIENT_ORDER_INDEX:
+                raise ValidationError("Generated client_order_index exceeds protocol maximum")
+            return client_order_index
+
     def create_auth_token_with_expiry(self, deadline: int = DEFAULT_10_MIN_AUTH_EXPIRY, *, timestamp: int = None, api_key_index: int = DEFAULT_API_KEY_INDEX):
         if deadline == SignerClient.DEFAULT_10_MIN_AUTH_EXPIRY:
             deadline = 10 * SignerClient.MINUTE
@@ -430,6 +506,22 @@ class SignerClient:
         auth = decode_and_free(result.str)
         error = decode_and_free(result.err)
         return auth, error
+
+    @staticmethod
+    def _normalize_order_expiry_for_tif(time_in_force: int, order_expiry: int) -> int:
+        if (
+            time_in_force == SignerClient.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL
+            and order_expiry == SignerClient.DEFAULT_28_DAY_ORDER_EXPIRY
+        ):
+            return SignerClient.DEFAULT_IOC_EXPIRY
+        if order_expiry > 0:
+            if order_expiry < 10_000_000_000:
+                raise ValidationError("order_expiry must be a Unix timestamp in milliseconds")
+
+            minimum_order_expiry = int(time.time() * 1000) + SignerClient.MIN_ORDER_EXPIRY_BUFFER_MS
+            if order_expiry < minimum_order_expiry:
+                raise ValidationError("order_expiry must be at least 5 minutes in the future")
+        return order_expiry
 
     def sign_change_api_key(self, eth_private_key: str, new_pubkey: str, skip_nonce: int = SKIP_NONCE_OFF, nonce: int = DEFAULT_NONCE, api_key_index: int = DEFAULT_API_KEY_INDEX) -> Union[Tuple[str, str, str, None], Tuple[None, None, None, str]]:
         return self.__decode_and_sign_tx_info(eth_private_key, self.signer.SignChangePubKey(
@@ -470,6 +562,7 @@ class SignerClient:
             nonce: int = DEFAULT_NONCE,
             api_key_index: int = DEFAULT_API_KEY_INDEX
     ) -> Union[Tuple[str, str, str, None], Tuple[None, None, None, str]]:
+        normalized_order_expiry = self._normalize_order_expiry_for_tif(time_in_force, order_expiry)
         return self.__decode_tx_info(self.signer.SignCreateOrder(
             market_index,
             client_order_index,
@@ -480,7 +573,7 @@ class SignerClient:
             time_in_force,
             reduce_only,
             trigger_price,
-            order_expiry,
+            normalized_order_expiry,
             integrator_account_index,
             integrator_taker_fee,
             integrator_maker_fee,
@@ -739,6 +832,98 @@ class SignerClient:
         ideal_price = int((ob_orders.bids[0].price if is_ask else ob_orders.asks[0].price).replace(".", ""))
         return ideal_price
 
+    async def get_market_index_symbol_map(self, *, include_perps: bool = True, include_spot: bool = True) -> Dict[int, str]:
+        details = await self.order_api.order_book_details()
+        mapping: Dict[int, str] = {}
+
+        if include_perps and details.order_book_details:
+            for market in details.order_book_details:
+                mapping[int(market.market_id)] = market.symbol
+
+        if include_spot and details.spot_order_book_details:
+            for market in details.spot_order_book_details:
+                mapping[int(market.market_id)] = market.symbol
+
+        return mapping
+
+    async def get_market_index_for_symbol(self, symbol: str, *, include_perps: bool = True, include_spot: bool = True) -> Optional[int]:
+        target = symbol.strip().upper()
+        market_map = await self.get_market_index_symbol_map(include_perps=include_perps, include_spot=include_spot)
+        for market_index, market_symbol in market_map.items():
+            if market_symbol.upper() == target:
+                return market_index
+        return None
+
+    async def fetch_positions(self, *, by: str = "index", value: Optional[str] = None) -> List[Any]:
+        if value is None:
+            value = str(self.account_index)
+        details = await self.account_api.account(by=by, value=value)
+        if not details.accounts:
+            return []
+        return details.accounts[0].positions
+
+    async def fetch_order(
+            self,
+            *,
+            order_id: Optional[str] = None,
+            client_order_index: Optional[int] = None,
+            market_id: Optional[int] = None,
+            auth: Optional[str] = None,
+            inactive_limit: int = 50,
+    ) -> Optional[Any]:
+        if order_id is None and client_order_index is None:
+            raise ValidationError("either order_id or client_order_index must be provided")
+
+        active_task = self.order_api.account_active_orders(
+            account_index=self.account_index,
+            market_id=market_id,
+            auth=auth,
+        )
+        inactive_task = self.order_api.account_inactive_orders(
+            account_index=self.account_index,
+            market_id=market_id,
+            auth=auth,
+            limit=inactive_limit,
+        )
+        active, inactive = await asyncio.gather(active_task, inactive_task)
+
+        for source in (active.orders, inactive.orders):
+            for order in source:
+                if order_id is not None and order.order_id == order_id:
+                    return order
+                if client_order_index is not None and order.client_order_index == client_order_index:
+                    return order
+        return None
+
+    async def get_leverage_info(self) -> Dict[int, Dict[str, Optional[float]]]:
+        positions = await self.fetch_positions()
+        market_details = await self.order_api.order_book_details()
+
+        def _fraction_to_int(value: Any) -> int:
+            if isinstance(value, int):
+                return value
+            if isinstance(value, float):
+                return int(value)
+            return int(float(str(value)))
+
+        max_leverage_by_market: Dict[int, Optional[float]] = {}
+        if market_details.order_book_details:
+            for market in market_details.order_book_details:
+                min_imf = _fraction_to_int(market.min_initial_margin_fraction)
+                max_leverage_by_market[int(market.market_id)] = (10000 / min_imf) if min_imf > 0 else None
+
+        result: Dict[int, Dict[str, Optional[float]]] = {}
+        for position in positions:
+            current_imf = _fraction_to_int(position.initial_margin_fraction)
+            current_leverage = (10000 / current_imf) if current_imf > 0 else None
+            result[int(position.market_id)] = {
+                "leverage": current_leverage,
+                "margin_mode": int(position.margin_mode),
+                "max_leverage": max_leverage_by_market.get(int(position.market_id)),
+            }
+
+        return result
+
     async def get_potential_execution_price(self, market_index, amount, is_ask, is_amount_base=True, ob_orders=None) -> (float, int):
         if ob_orders is None:
             ob_orders = await self.order_api.order_book_orders(market_index, 100)
@@ -952,7 +1137,42 @@ class SignerClient:
             self.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL,
             reduce_only,
             trigger_price,
-            self.DEFAULT_28_DAY_ORDER_EXPIRY,
+            self.DEFAULT_IOC_EXPIRY,
+            integrator_account_index=integrator_account_index,
+            integrator_taker_fee=integrator_taker_fee,
+            integrator_maker_fee=integrator_maker_fee,
+            nonce=nonce,
+            api_key_index=api_key_index,
+        )
+
+    async def create_tp_market_order_limited_slippage(
+            self,
+            market_index,
+            client_order_index,
+            base_amount,
+            trigger_price,
+            max_slippage,
+            is_ask,
+            reduce_only=False,
+            *,
+            integrator_account_index: int = 0,
+            integrator_taker_fee: int = 0,
+            integrator_maker_fee: int = 0,
+            ideal_price=None,
+            nonce: int = DEFAULT_NONCE,
+            api_key_index: int = DEFAULT_API_KEY_INDEX
+        ) -> Union[Tuple[CreateOrder, RespSendTx, None], Tuple[None, None, str]]:
+        if ideal_price is None:
+            ideal_price = trigger_price
+        acceptable_execution_price = round(ideal_price * (1 + max_slippage * (-1 if is_ask else 1)))
+        return await self.create_tp_order(
+            market_index=market_index,
+            client_order_index=client_order_index,
+            base_amount=base_amount,
+            trigger_price=trigger_price,
+            price=acceptable_execution_price,
+            is_ask=is_ask,
+            reduce_only=reduce_only,
             integrator_account_index=integrator_account_index,
             integrator_taker_fee=integrator_taker_fee,
             integrator_maker_fee=integrator_maker_fee,
@@ -1024,7 +1244,72 @@ class SignerClient:
             self.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL,
             reduce_only,
             trigger_price,
-            self.DEFAULT_28_DAY_ORDER_EXPIRY,
+            self.DEFAULT_IOC_EXPIRY,
+            integrator_account_index=integrator_account_index,
+            integrator_taker_fee=integrator_taker_fee,
+            integrator_maker_fee=integrator_maker_fee,
+            nonce=nonce,
+            api_key_index=api_key_index,
+        )
+
+    async def create_sl_market_order(
+            self,
+            market_index,
+            client_order_index,
+            base_amount,
+            trigger_price,
+            is_ask,
+            reduce_only=False,
+            *,
+            integrator_account_index: int = 0,
+            integrator_taker_fee: int = 0,
+            integrator_maker_fee: int = 0,
+            nonce: int = DEFAULT_NONCE,
+            api_key_index: int = DEFAULT_API_KEY_INDEX
+        ) -> Union[Tuple[CreateOrder, RespSendTx, None], Tuple[None, None, str]]:
+        return await self.create_sl_order(
+            market_index=market_index,
+            client_order_index=client_order_index,
+            base_amount=base_amount,
+            trigger_price=trigger_price,
+            price=trigger_price,
+            is_ask=is_ask,
+            reduce_only=reduce_only,
+            integrator_account_index=integrator_account_index,
+            integrator_taker_fee=integrator_taker_fee,
+            integrator_maker_fee=integrator_maker_fee,
+            nonce=nonce,
+            api_key_index=api_key_index,
+        )
+
+    async def create_sl_market_order_limited_slippage(
+            self,
+            market_index,
+            client_order_index,
+            base_amount,
+            trigger_price,
+            max_slippage,
+            is_ask,
+            reduce_only=False,
+            *,
+            integrator_account_index: int = 0,
+            integrator_taker_fee: int = 0,
+            integrator_maker_fee: int = 0,
+            ideal_price=None,
+            nonce: int = DEFAULT_NONCE,
+            api_key_index: int = DEFAULT_API_KEY_INDEX
+        ) -> Union[Tuple[CreateOrder, RespSendTx, None], Tuple[None, None, str]]:
+        if ideal_price is None:
+            ideal_price = trigger_price
+        acceptable_execution_price = round(ideal_price * (1 + max_slippage * (-1 if is_ask else 1)))
+        return await self.create_sl_order(
+            market_index=market_index,
+            client_order_index=client_order_index,
+            base_amount=base_amount,
+            trigger_price=trigger_price,
+            price=acceptable_execution_price,
+            is_ask=is_ask,
+            reduce_only=reduce_only,
             integrator_account_index=integrator_account_index,
             integrator_taker_fee=integrator_taker_fee,
             integrator_maker_fee=integrator_maker_fee,
@@ -1345,7 +1630,17 @@ class SignerClient:
     async def send_tx(self, tx_type: StrictInt, tx_info: str) -> RespSendTx:
         if tx_info[0] != "{":
             raise Exception(tx_info)
-        return await self.tx_api.send_tx(tx_type=tx_type, tx_info=tx_info)
+        response = await self.tx_api.send_tx(tx_type=tx_type, tx_info=tx_info)
+        parsed_message = self._try_parse_json_message(response.message)
+        if parsed_message is not None:
+            response.additional_properties["parsed_message"] = parsed_message
+        if response.code in (21120, 21136):
+            response.additional_properties["troubleshooting"] = (
+                "invalid signature/public key: ensure chain_id matches network, "
+                "re-generate/refresh API key pair, initialize SignerClient with api_private_keys={api_key_index: private_key}, "
+                "and use API key indexes 4-254 for bots"
+            )
+        return response
 
     async def send_tx_batch(self, tx_types: List[StrictInt], tx_infos: List[str]) -> RespSendTxBatch:
         if len(tx_types) != len(tx_infos):
@@ -1355,10 +1650,17 @@ class SignerClient:
 
         if tx_infos[0][0] != "{":
             raise Exception(tx_infos)
-        return await self.tx_api.send_tx_batch(tx_types=json.dumps(tx_types), tx_infos=json.dumps(tx_infos))
+        response = await self.tx_api.send_tx_batch(tx_types=json.dumps(tx_types), tx_infos=json.dumps(tx_infos))
+        parsed_message = self._try_parse_json_message(response.message)
+        if parsed_message is not None:
+            response.additional_properties["parsed_message"] = parsed_message
+        return response
 
     async def close(self):
         await self.api_client.close()
+        if getattr(self, "_signer_temp_dir", None):
+            shutil.rmtree(self._signer_temp_dir, ignore_errors=True)
+            self._signer_temp_dir = None
 
     @staticmethod
     def are_keys_equal(key1, key2) -> bool:
@@ -1368,3 +1670,13 @@ class SignerClient:
         if key2.startswith("0x"):
             start_index2 = 2
         return key1[start_index1:] == key2[start_index2:]
+
+    @staticmethod
+    def _try_parse_json_message(message: Optional[str]) -> Optional[dict]:
+        if not message:
+            return None
+        try:
+            parsed = json.loads(message)
+            return parsed if isinstance(parsed, dict) else None
+        except (json.JSONDecodeError, TypeError):
+            return None

--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -1159,6 +1159,7 @@ class SignerClient:
             integrator_taker_fee: int = 0,
             integrator_maker_fee: int = 0,
             ideal_price=None,
+            skip_nonce: int = SKIP_NONCE_OFF,
             nonce: int = DEFAULT_NONCE,
             api_key_index: int = DEFAULT_API_KEY_INDEX
         ) -> Union[Tuple[CreateOrder, RespSendTx, None], Tuple[None, None, str]]:
@@ -1296,6 +1297,7 @@ class SignerClient:
             integrator_taker_fee: int = 0,
             integrator_maker_fee: int = 0,
             ideal_price=None,
+            skip_nonce: int = SKIP_NONCE_OFF,
             nonce: int = DEFAULT_NONCE,
             api_key_index: int = DEFAULT_API_KEY_INDEX
         ) -> Union[Tuple[CreateOrder, RespSendTx, None], Tuple[None, None, str]]:

--- a/lighter/ws_client.py
+++ b/lighter/ws_client.py
@@ -1,7 +1,10 @@
+import asyncio
 import json
+import threading
 from websockets.sync.client import connect
-from websockets.client import connect as connect_async
+from websockets import connect as connect_async
 from lighter.configuration import Configuration
+
 
 class WsClient:
     def __init__(
@@ -12,6 +15,9 @@ class WsClient:
         account_ids=[],
         on_order_book_update=print,
         on_account_update=print,
+        on_gap_detected=print,
+        ping_interval_seconds=90,
+        verify_orderbook_nonce=True,
     ):
         if host is None:
             host = Configuration.get_default().host.replace("https://", "")
@@ -27,12 +33,18 @@ class WsClient:
             raise Exception("No subscriptions provided.")
 
         self.order_book_states = {}
+        self.order_book_last_nonce = {}
         self.account_states = {}
 
         self.on_order_book_update = on_order_book_update
         self.on_account_update = on_account_update
+        self.on_gap_detected = on_gap_detected
+
+        self.verify_orderbook_nonce = verify_orderbook_nonce
+        self.ping_interval_seconds = ping_interval_seconds
 
         self.ws = None
+        self._sync_keepalive_stop = threading.Event()
 
     def on_message(self, ws, message):
         if isinstance(message, str):
@@ -45,28 +57,39 @@ class WsClient:
         elif message_type == "subscribed/order_book":
             self.handle_subscribed_order_book(message)
         elif message_type == "update/order_book":
-            self.handle_update_order_book(message)
+            self.handle_update_order_book(ws, message)
         elif message_type == "subscribed/account_all":
             self.handle_subscribed_account(message)
         elif message_type == "update/account_all":
             self.handle_update_account(message)
         elif message_type == "ping":
-            # Respond to ping with pong
             ws.send(json.dumps({"type": "pong"}))
         else:
             self.handle_unhandled_message(message)
 
     async def on_message_async(self, ws, message):
-        message = json.loads(message)
+        if isinstance(message, str):
+            message = json.loads(message)
+
+        if not isinstance(message, dict):
+            return
+
         message_type = message.get("type")
 
         if message_type == "connected":
             await self.handle_connected_async(ws)
+        elif message_type == "subscribed/order_book":
+            self.handle_subscribed_order_book(message)
+        elif message_type == "update/order_book":
+            await self.handle_update_order_book_async(ws, message)
+        elif message_type == "subscribed/account_all":
+            self.handle_subscribed_account(message)
+        elif message_type == "update/account_all":
+            self.handle_update_account(message)
         elif message_type == "ping":
-            # Respond to ping with pong
             await ws.send(json.dumps({"type": "pong"}))
         else:
-            self.on_message(ws, message)
+            self.handle_unhandled_message(message)
 
     def handle_connected(self, ws):
         for market_id in self.subscriptions["order_books"]:
@@ -95,16 +118,77 @@ class WsClient:
     def handle_subscribed_order_book(self, message):
         market_id = message["channel"].split(":")[1]
         self.order_book_states[market_id] = message["order_book"]
+        self.order_book_last_nonce[market_id] = message["order_book"].get("nonce")
         if self.on_order_book_update:
             self.on_order_book_update(market_id, self.order_book_states[market_id])
 
-    def handle_update_order_book(self, message):
+    def _nonce_gap_detected(self, market_id, order_book):
+        if not self.verify_orderbook_nonce:
+            return False
+
+        begin_nonce = order_book.get("begin_nonce")
+        prev_nonce = self.order_book_last_nonce.get(market_id)
+
+        if begin_nonce is None or prev_nonce is None:
+            return False
+
+        return begin_nonce != prev_nonce
+
+    def _resubscribe_order_book(self, ws, market_id):
+        ws.send(json.dumps({"type": "subscribe", "channel": f"order_book/{market_id}"}))
+
+    async def _resubscribe_order_book_async(self, ws, market_id):
+        await ws.send(json.dumps({"type": "subscribe", "channel": f"order_book/{market_id}"}))
+
+    def handle_update_order_book(self, ws, message):
         market_id = message["channel"].split(":")[1]
-        self.update_order_book_state(market_id, message["order_book"])
+        order_book = message["order_book"]
+
+        if self._nonce_gap_detected(market_id, order_book):
+            if self.on_gap_detected:
+                self.on_gap_detected(
+                    {
+                        "type": "order_book_nonce_gap",
+                        "market_id": market_id,
+                        "expected_begin_nonce": self.order_book_last_nonce.get(market_id),
+                        "actual_begin_nonce": order_book.get("begin_nonce"),
+                    }
+                )
+            self._resubscribe_order_book(ws, market_id)
+            return
+
+        self.update_order_book_state(market_id, order_book)
+        self.order_book_last_nonce[market_id] = order_book.get("nonce", self.order_book_last_nonce.get(market_id))
+        if self.on_order_book_update:
+            self.on_order_book_update(market_id, self.order_book_states[market_id])
+
+    async def handle_update_order_book_async(self, ws, message):
+        market_id = message["channel"].split(":")[1]
+        order_book = message["order_book"]
+
+        if self._nonce_gap_detected(market_id, order_book):
+            if self.on_gap_detected:
+                self.on_gap_detected(
+                    {
+                        "type": "order_book_nonce_gap",
+                        "market_id": market_id,
+                        "expected_begin_nonce": self.order_book_last_nonce.get(market_id),
+                        "actual_begin_nonce": order_book.get("begin_nonce"),
+                    }
+                )
+            await self._resubscribe_order_book_async(ws, market_id)
+            return
+
+        self.update_order_book_state(market_id, order_book)
+        self.order_book_last_nonce[market_id] = order_book.get("nonce", self.order_book_last_nonce.get(market_id))
         if self.on_order_book_update:
             self.on_order_book_update(market_id, self.order_book_states[market_id])
 
     def update_order_book_state(self, market_id, order_book):
+        if market_id not in self.order_book_states:
+            self.order_book_states[market_id] = order_book
+            return
+
         self.update_orders(
             order_book["asks"], self.order_book_states[market_id]["asks"]
         )
@@ -115,7 +199,6 @@ class WsClient:
     def update_orders(self, new_orders, existing_orders):
         for new_order in new_orders:
             is_new_order = True
-            # iterate over a copy so removal is safe
             existing_order_copy = existing_orders[:]
             for existing_order in existing_order_copy:
                 if new_order["price"] == existing_order["price"]:
@@ -127,7 +210,6 @@ class WsClient:
             if is_new_order:
                 existing_orders.append(new_order)
 
-        # final cleanup (in-place)
         existing_orders[:] = [
             order for order in existing_orders if float(order["size"]) > 0
         ]
@@ -153,16 +235,42 @@ class WsClient:
     def on_close(self, ws, close_status_code, close_msg):
         raise Exception(f"Closed: {close_status_code} {close_msg}")
 
+    def _sync_keepalive(self, ws):
+        while not self._sync_keepalive_stop.wait(self.ping_interval_seconds):
+            try:
+                ws.ping()
+            except Exception:
+                return
+
+    async def _async_keepalive(self, ws):
+        while True:
+            await asyncio.sleep(self.ping_interval_seconds)
+            try:
+                await ws.ping()
+            except Exception:
+                return
+
     def run(self):
         ws = connect(self.base_url)
         self.ws = ws
 
-        for message in ws:
-            self.on_message(ws, message)
+        self._sync_keepalive_stop.clear()
+        keepalive_thread = threading.Thread(target=self._sync_keepalive, args=(ws,), daemon=True)
+        keepalive_thread.start()
+
+        try:
+            for message in ws:
+                self.on_message(ws, message)
+        finally:
+            self._sync_keepalive_stop.set()
 
     async def run_async(self):
         ws = await connect_async(self.base_url)
         self.ws = ws
 
-        async for message in ws:
-            await self.on_message_async(ws, message)
+        keepalive_task = asyncio.create_task(self._async_keepalive(ws))
+        try:
+            async for message in ws:
+                await self.on_message_async(ws, message)
+        finally:
+            keepalive_task.cancel()

--- a/openapi.json
+++ b/openapi.json
@@ -5294,7 +5294,7 @@
         "order_expiry": {
           "type": "integer",
           "format": "int64",
-          "example": "1640995200"
+          "example": "1640995200000"
         },
         "status": {
           "type": "string",
@@ -8610,7 +8610,7 @@
         "order_expiry": {
           "type": "integer",
           "format": "int64",
-          "example": "1640995200"
+          "example": "1640995200000"
         },
         "transaction_time": {
           "type": "integer",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = ["lighter"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 1.25.3"
+urllib3 = ">= 2.6.3"
 python-dateutil = ">=2.8.2"
 aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = ["lighter"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 2.2.3"
+urllib3 = ">= 1.26.18"
 python-dateutil = ">=2.8.2"
 aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = ["lighter"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-urllib3 = ">= 2.6.3"
+urllib3 = ">= 2.2.3"
 python-dateutil = ">=2.8.2"
 aiohttp = ">= 3.8.4"
 aiohttp-retry = ">= 2.8.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 2.2.3
+urllib3 >= 1.26.18
 pydantic >= 2
 typing-extensions >= 4.7.1
 aiohttp >= 3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 2.6.3
+urllib3 >= 2.2.3
 pydantic >= 2
 typing-extensions >= 4.7.1
 aiohttp >= 3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 2.6.3
 pydantic >= 2
 typing-extensions >= 4.7.1
 aiohttp >= 3.0.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ NAME = "lighter-sdk"
 VERSION = "1.0.8"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 2.6.3",
     "python-dateutil",
     "aiohttp >= 3.0.0",
     "aiohttp-retry >= 2.8.3",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ NAME = "lighter-sdk"
 VERSION = "1.0.8"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 2.2.3",
+    "urllib3 >= 1.26.18",
     "python-dateutil",
     "aiohttp >= 3.0.0",
     "aiohttp-retry >= 2.8.3",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ NAME = "lighter-sdk"
 VERSION = "1.0.8"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 2.6.3",
+    "urllib3 >= 2.2.3",
     "python-dateutil",
     "aiohttp >= 3.0.0",
     "aiohttp-retry >= 2.8.3",

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -230,7 +230,7 @@ def test_sign_update_leverage_forwards_margin_mode_to_signer():
     finally:
         SignerClient._SignerClient__decode_tx_info = original_decode
 
-    assert fake_signer.captured_args == (3, 500, SignerClient.ISOLATED_MARGIN_MODE, 17, 9, 42)
+    assert fake_signer.captured_args == (3, 500, SignerClient.ISOLATED_MARGIN_MODE, SignerClient.SKIP_NONCE_OFF, 17, 9, 42)
 
 
 def test_update_leverage_keeps_public_margin_mode_and_fraction_mapping():
@@ -240,8 +240,8 @@ def test_update_leverage_keeps_public_margin_mode_and_fraction_mapping():
 
     captured = {}
 
-    def fake_sign_update_leverage(market_index, fraction, margin_mode, nonce, api_key_index):
-        captured["args"] = (market_index, fraction, margin_mode, nonce, api_key_index)
+    def fake_sign_update_leverage(market_index, fraction, margin_mode, skip_nonce, nonce, api_key_index):
+        captured["args"] = (market_index, fraction, margin_mode, skip_nonce, nonce, api_key_index)
         return 1, '{"MarginMode":1}', '0xabc', None
 
     client.sign_update_leverage = fake_sign_update_leverage
@@ -257,7 +257,7 @@ def test_update_leverage_keeps_public_margin_mode_and_fraction_mapping():
         )
     )
 
-    assert captured["args"] == (3, 500, SignerClient.ISOLATED_MARGIN_MODE, 17, 9)
+    assert captured["args"] == (3, 500, SignerClient.ISOLATED_MARGIN_MODE, SignerClient.SKIP_NONCE_OFF, 17, 9)
 
 
 def test_package_version_matches_distribution_metadata_when_installed():
@@ -445,6 +445,7 @@ def test_sign_withdraw_forwards_asset_route_and_amount():
         SignerClient.ASSET_ID_USDC,
         SignerClient.ROUTE_SPOT,
         123456,
+        SignerClient.SKIP_NONCE_OFF,
         9,
         7,
         42,
@@ -617,9 +618,10 @@ def test_sign_create_grouped_orders_forwards_grouping_type_and_order_count():
     captured = {}
 
     class FakeSigner:
-        def SignCreateGroupedOrders(self, grouping_type, orders_arr, count, nonce, api_key_index, account_index):
+        def SignCreateGroupedOrders(self, grouping_type, orders_arr, count, integrator_account_index, integrator_taker_fee, integrator_maker_fee, skip_nonce, nonce, api_key_index, account_index):
             captured["grouping_type"] = grouping_type
             captured["count"] = count
+            captured["skip_nonce"] = skip_nonce
             captured["nonce"] = nonce
             captured["api_key_index"] = api_key_index
             # return a SignedTxResponse-like object with null fields so decode works
@@ -656,6 +658,7 @@ def test_sign_create_grouped_orders_forwards_grouping_type_and_order_count():
 
     assert captured["grouping_type"] == SignerClient.GROUPING_TYPE_ONE_CANCELS_THE_OTHER
     assert captured["count"] == 2
+    assert captured["skip_nonce"] == SignerClient.SKIP_NONCE_OFF
     assert captured["nonce"] == 42
     assert captured["api_key_index"] == 7
 

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -1,0 +1,922 @@
+import json
+import asyncio
+import importlib.metadata as importlib_metadata
+from unittest.mock import AsyncMock, patch
+
+import lighter
+import pytest
+import lighter.signer_client as signer_client_module
+from lighter.configuration import Configuration
+from lighter.rest import RESTClientObject
+from lighter.models.candle import Candle
+from lighter.models.resp_send_tx import RespSendTx
+from lighter.models.candles import Candles
+from lighter.models.account_position import AccountPosition
+from lighter.models.trade import Trade
+from lighter.signer_client import SignerClient
+from lighter.ws_client import WsClient
+
+
+def test_candle_ohlc_lowercase_fields_parse():
+    candle = Candle.from_dict(
+        {
+            "t": 1771028220000,
+            "o": 0.096567,
+            "h": 0.096567,
+            "l": 0.096470,
+            "c": 0.096470,
+            "v": 10,
+            "V": 0.96504,
+            "i": 14278974494,
+        }
+    )
+
+    assert candle is not None
+    assert candle.o == 0.096567
+    assert candle.h == 0.096567
+    assert candle.l == 0.096470
+    assert candle.c == 0.096470
+
+
+def test_candles_model_nested_candles_parse():
+    response = {
+        "code": 200,
+        "r": "1m",
+        "c": [
+            {
+                "t": 1771028220000,
+                "o": 0.096567,
+                "h": 0.096567,
+                "l": 0.096470,
+                "c": 0.096470,
+                "v": 10,
+                "V": 0.96504,
+                "i": 14278974494,
+            }
+        ],
+    }
+
+    candles = Candles.from_dict(response)
+    assert candles is not None
+    assert candles.code == 200
+    assert candles.c is not None
+    assert len(candles.c) == 1
+    assert candles.c[0].o == 0.096567
+    assert candles.c[0].c == 0.096470
+
+
+def test_parse_message_helper_extracts_json_dict():
+    payload = json.dumps({"reason": "not_filled", "source": "engine"})
+    parsed = SignerClient._try_parse_json_message(payload)
+    assert parsed == {"reason": "not_filled", "source": "engine"}
+
+
+def test_chain_id_inference():
+    assert SignerClient._infer_chain_id("https://mainnet.zklighter.elliot.ai") == 304
+    assert SignerClient._infer_chain_id("https://testnet.zklighter.elliot.ai") == 300
+
+
+def test_ioc_default_order_expiry_is_normalized_to_zero():
+    normalized = SignerClient._normalize_order_expiry_for_tif(
+        SignerClient.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL,
+        SignerClient.DEFAULT_28_DAY_ORDER_EXPIRY,
+    )
+    assert normalized == SignerClient.DEFAULT_IOC_EXPIRY
+
+
+def test_non_ioc_order_expiry_keeps_default_28_day_value():
+    normalized = SignerClient._normalize_order_expiry_for_tif(
+        SignerClient.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
+        SignerClient.DEFAULT_28_DAY_ORDER_EXPIRY,
+    )
+    assert normalized == SignerClient.DEFAULT_28_DAY_ORDER_EXPIRY
+
+
+def test_order_expiry_rejects_seconds_timestamp():
+    with pytest.raises(ValueError, match="milliseconds"):
+        SignerClient._normalize_order_expiry_for_tif(
+            SignerClient.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
+            1_763_031_600,
+        )
+
+
+def test_order_expiry_rejects_expiry_less_than_five_minutes_out():
+    with patch("lighter.signer_client.time.time", return_value=1_700_000_000):
+        with pytest.raises(ValueError, match="at least 5 minutes in the future"):
+            SignerClient._normalize_order_expiry_for_tif(
+                SignerClient.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
+                1_700_000_000_000 + (4 * 60 * 1000),
+            )
+
+
+def test_linux_aarch64_loads_arm_shared_library():
+    captured_path = None
+
+    class FakeFunction:
+        def __init__(self):
+            self.argtypes = None
+            self.restype = None
+
+    class FakeLibrary:
+        def __init__(self):
+            self.GenerateAPIKey = FakeFunction()
+            self.CreateClient = FakeFunction()
+            self.CheckClient = FakeFunction()
+            self.SignChangePubKey = FakeFunction()
+            self.SignCreateOrder = FakeFunction()
+            self.SignCreateGroupedOrders = FakeFunction()
+            self.SignCancelOrder = FakeFunction()
+            self.SignWithdraw = FakeFunction()
+            self.SignCreateSubAccount = FakeFunction()
+            self.SignCancelAllOrders = FakeFunction()
+            self.SignModifyOrder = FakeFunction()
+            self.SignTransfer = FakeFunction()
+            self.SignCreatePublicPool = FakeFunction()
+            self.SignUpdatePublicPool = FakeFunction()
+            self.SignMintShares = FakeFunction()
+            self.SignBurnShares = FakeFunction()
+            self.SignStakeAssets = FakeFunction()
+            self.SignUnstakeAssets = FakeFunction()
+            self.SignUpdateLeverage = FakeFunction()
+            self.CreateAuthToken = FakeFunction()
+            self.SignUpdateMargin = FakeFunction()
+            self.SignApproveIntegrator = FakeFunction()
+
+    def fake_cdll(path):
+        nonlocal captured_path
+        captured_path = path
+        return FakeLibrary()
+
+    with patch("lighter.signer_client.platform.system", return_value="Linux"), patch(
+        "lighter.signer_client.platform.machine", return_value="aarch64"
+    ), patch("lighter.signer_client.ctypes.CDLL", side_effect=fake_cdll):
+        loaded, temp_dir = signer_client_module.__get_shared_library()
+
+    assert loaded is not None
+    assert temp_dir is None
+    assert captured_path is not None
+    assert captured_path.endswith("lighter-signer-linux-arm64.so")
+
+
+def test_signer_client_requests_isolated_signer_instance_per_client():
+    signer_instances = []
+    requested_modes = []
+
+    class FakeSigner:
+        def CreateClient(self, *args):
+            return None
+
+    class DummyApiClient:
+        async def close(self):
+            return None
+
+    class DummyNonceManager:
+        def next_nonce(self):
+            return 255, 1
+
+    def fake_get_signer(*, isolated=False):
+        requested_modes.append(isolated)
+        signer = FakeSigner()
+        signer_instances.append(signer)
+        return signer, None
+
+    with patch("lighter.signer_client.get_signer", side_effect=fake_get_signer), patch(
+        "lighter.signer_client.nonce_manager.nonce_manager_factory",
+        return_value=DummyNonceManager(),
+    ), patch("lighter.signer_client.lighter.ApiClient", return_value=DummyApiClient()), patch(
+        "lighter.signer_client.lighter.TransactionApi", return_value=object()
+    ), patch("lighter.signer_client.lighter.OrderApi", return_value=object()):
+        first_client = SignerClient(
+            url="https://testnet.zklighter.elliot.ai",
+            account_index=1,
+            api_private_keys={2: "abc"},
+        )
+        second_client = SignerClient(
+            url="https://testnet.zklighter.elliot.ai",
+            account_index=2,
+            api_private_keys={2: "def"},
+        )
+
+    assert requested_modes == [True, True]
+    assert first_client.signer is not second_client.signer
+
+
+def test_sign_update_leverage_forwards_margin_mode_to_signer():
+    class FakeSigner:
+        def __init__(self):
+            self.captured_args = None
+
+        def SignUpdateLeverage(self, *args):
+            self.captured_args = args
+            return args
+
+    fake_signer = FakeSigner()
+    client = object.__new__(SignerClient)
+    client.signer = fake_signer
+    client.account_index = 42
+
+    original_decode = SignerClient._SignerClient__decode_tx_info
+    SignerClient._SignerClient__decode_tx_info = staticmethod(lambda result: result)
+    try:
+        SignerClient.sign_update_leverage(
+            client,
+            market_index=3,
+            fraction=500,
+            margin_mode=SignerClient.ISOLATED_MARGIN_MODE,
+            nonce=17,
+            api_key_index=9,
+        )
+    finally:
+        SignerClient._SignerClient__decode_tx_info = original_decode
+
+    assert fake_signer.captured_args == (3, 500, SignerClient.ISOLATED_MARGIN_MODE, 17, 9, 42)
+
+
+def test_update_leverage_keeps_public_margin_mode_and_fraction_mapping():
+    client = object.__new__(SignerClient)
+    client.sign_update_leverage = lambda *args: (1, '{"MarginMode":1}', '0xabc', None)
+    client.send_tx = AsyncMock(return_value=RespSendTx(code=200, message="ok", tx_hash="0xabc", predicted_execution_time_ms=0, volume_quota_remaining=0))
+
+    captured = {}
+
+    def fake_sign_update_leverage(market_index, fraction, margin_mode, nonce, api_key_index):
+        captured["args"] = (market_index, fraction, margin_mode, nonce, api_key_index)
+        return 1, '{"MarginMode":1}', '0xabc', None
+
+    client.sign_update_leverage = fake_sign_update_leverage
+
+    asyncio.run(
+        SignerClient.update_leverage(
+            client,
+            market_index=3,
+            margin_mode=SignerClient.ISOLATED_MARGIN_MODE,
+            leverage=20,
+            nonce=17,
+            api_key_index=9,
+        )
+    )
+
+    assert captured["args"] == (3, 500, SignerClient.ISOLATED_MARGIN_MODE, 17, 9)
+
+
+def test_package_version_matches_distribution_metadata_when_installed():
+    try:
+        installed_version = importlib_metadata.version("lighter-sdk")
+    except importlib_metadata.PackageNotFoundError:
+        assert lighter.__version__ == "0+unknown"
+        return
+
+    assert lighter.__version__ == installed_version
+
+
+def test_send_tx_sets_troubleshooting_for_invalid_public_key_errors():
+    client = object.__new__(SignerClient)
+    client.tx_api = AsyncMock()
+    client.tx_api.send_tx.return_value = RespSendTx(
+        code=21136,
+        message="invalid PublicKey",
+        tx_hash="0x1",
+        predicted_execution_time_ms=0,
+        volume_quota_remaining=0,
+    )
+
+    response = asyncio.run(SignerClient.send_tx(client, tx_type=1, tx_info='{"a":1}'))
+
+    troubleshooting = response.additional_properties.get("troubleshooting")
+    assert troubleshooting is not None
+    assert "api_private_keys" in troubleshooting
+
+
+def test_create_auth_token_with_expiry_adds_timestamp_to_deadline():
+    class FakeSigner:
+        def __init__(self):
+            self.captured_args = None
+
+        def CreateAuthToken(self, *args):
+            self.captured_args = args
+            return type("Result", (), {"str": "token", "err": None})()
+
+    client = object.__new__(SignerClient)
+    client.signer = FakeSigner()
+    client.account_index = 42
+
+    with patch("lighter.signer_client.decode_and_free", side_effect=lambda value: value):
+        auth, error = SignerClient.create_auth_token_with_expiry(
+            client,
+            deadline=3600,
+            timestamp=1_700_000_000,
+            api_key_index=7,
+        )
+
+    assert auth == "token"
+    assert error is None
+    assert client.signer.captured_args == (1_700_003_600, 7, 42)
+
+
+def test_create_auth_token_with_default_expiry_uses_ten_minutes():
+    class FakeSigner:
+        def __init__(self):
+            self.captured_args = None
+
+        def CreateAuthToken(self, *args):
+            self.captured_args = args
+            return type("Result", (), {"str": "token", "err": None})()
+
+    client = object.__new__(SignerClient)
+    client.signer = FakeSigner()
+    client.account_index = 99
+
+    with patch("lighter.signer_client.decode_and_free", side_effect=lambda value: value):
+        SignerClient.create_auth_token_with_expiry(client, timestamp=1_700_000_000, api_key_index=5)
+
+    assert client.signer.captured_args == (1_700_000_600, 5, 99)
+
+
+def test_sign_create_order_forwards_market_index_to_signer_call():
+    class FakeSigner:
+        def __init__(self):
+            self.captured_args = None
+
+        def SignCreateOrder(self, *args):
+            self.captured_args = args
+            return args
+
+    fake_signer = FakeSigner()
+    client = object.__new__(SignerClient)
+    client.signer = fake_signer
+    client.account_index = 42
+
+    original_decode = SignerClient._SignerClient__decode_tx_info
+    SignerClient._SignerClient__decode_tx_info = staticmethod(lambda result: result)
+    try:
+        SignerClient.sign_create_order(
+            client,
+            market_index=2048,
+            client_order_index=1,
+            base_amount=100,
+            price=123456,
+            is_ask=False,
+            order_type=SignerClient.ORDER_TYPE_LIMIT,
+            time_in_force=SignerClient.ORDER_TIME_IN_FORCE_GOOD_TILL_TIME,
+            reduce_only=False,
+            trigger_price=0,
+            order_expiry=SignerClient.DEFAULT_28_DAY_ORDER_EXPIRY,
+            nonce=7,
+            api_key_index=5,
+        )
+    finally:
+        SignerClient._SignerClient__decode_tx_info = original_decode
+
+    assert fake_signer.captured_args is not None
+    assert fake_signer.captured_args[0] == 2048
+
+
+def test_rest_client_includes_configured_proxy_in_requests():
+    class DummyResponse:
+        status = 200
+        reason = "OK"
+        headers = {}
+
+        async def read(self):
+            return b"{}"
+
+    class CaptureRequester:
+        def __init__(self):
+            self.last_kwargs = None
+
+        async def request(self, **kwargs):
+            self.last_kwargs = kwargs
+            return DummyResponse()
+
+    async def run_case():
+        cfg = Configuration()
+        cfg.proxy = "http://127.0.0.1:8080"
+        cfg.proxy_headers = {"Proxy-Authorization": "Basic abc"}
+
+        rest_client = RESTClientObject(cfg)
+        original_pool_manager = rest_client.pool_manager
+        capture = CaptureRequester()
+        rest_client.pool_manager = capture
+
+        try:
+            await rest_client.request("GET", "https://example.com")
+        finally:
+            await original_pool_manager.close()
+            if rest_client.retry_client is not None:
+                await rest_client.retry_client.close()
+
+        assert capture.last_kwargs is not None
+        assert capture.last_kwargs.get("proxy") == "http://127.0.0.1:8080"
+        assert capture.last_kwargs.get("proxy_headers") == {"Proxy-Authorization": "Basic abc"}
+
+    asyncio.run(run_case())
+
+
+def test_sign_withdraw_forwards_asset_route_and_amount():
+    class FakeSigner:
+        def __init__(self):
+            self.captured_args = None
+
+        def SignWithdraw(self, *args):
+            self.captured_args = args
+            return args
+
+    fake_signer = FakeSigner()
+    client = object.__new__(SignerClient)
+    client.signer = fake_signer
+    client.account_index = 42
+
+    original_decode = SignerClient._SignerClient__decode_tx_info
+    SignerClient._SignerClient__decode_tx_info = staticmethod(lambda result: result)
+    try:
+        SignerClient.sign_withdraw(
+            client,
+            asset_index=SignerClient.ASSET_ID_USDC,
+            route_type=SignerClient.ROUTE_SPOT,
+            amount=123456,
+            nonce=9,
+            api_key_index=7,
+        )
+    finally:
+        SignerClient._SignerClient__decode_tx_info = original_decode
+
+    assert fake_signer.captured_args == (
+        SignerClient.ASSET_ID_USDC,
+        SignerClient.ROUTE_SPOT,
+        123456,
+        9,
+        7,
+        42,
+    )
+
+
+def test_ws_client_replies_to_application_ping_with_pong():
+    sent_messages = []
+
+    class FakeWs:
+        def send(self, message):
+            sent_messages.append(json.loads(message))
+
+    client = WsClient(order_book_ids=[0], on_order_book_update=None, on_account_update=None)
+    client.on_message(FakeWs(), {"type": "ping"})
+
+    assert sent_messages == [{"type": "pong"}]
+
+
+def test_ws_client_sync_keepalive_uses_protocol_ping():
+    ping_calls = []
+
+    class FakeStopEvent:
+        def __init__(self):
+            self.calls = 0
+
+        def wait(self, timeout):
+            self.calls += 1
+            return self.calls > 1
+
+    class FakeWs:
+        def ping(self):
+            ping_calls.append("ping")
+
+    client = WsClient(order_book_ids=[0], on_order_book_update=None, on_account_update=None)
+    client._sync_keepalive_stop = FakeStopEvent()
+
+    client._sync_keepalive(FakeWs())
+
+    assert ping_calls == ["ping"]
+
+
+def test_withdraw_raises_for_unsupported_asset_id():
+    client = object.__new__(SignerClient)
+
+    with pytest.raises(ValueError, match="Unsupported asset id"):
+        asyncio.run(
+            SignerClient.withdraw(
+                client,
+                asset_id=9999,
+                route_type=SignerClient.ROUTE_SPOT,
+                amount=1.0,
+                nonce=1,
+                api_key_index=1,
+            )
+        )
+
+
+def test_create_market_order_keeps_price_scaling_same_for_buy_and_sell():
+    client = object.__new__(SignerClient)
+    client.create_order = AsyncMock(return_value=(None, None, None))
+
+    asyncio.run(
+        SignerClient.create_market_order(
+            client,
+            market_index=2,
+            client_order_index=1,
+            base_amount=100,
+            avg_execution_price=1_400_000,
+            is_ask=False,
+            nonce=11,
+            api_key_index=3,
+        )
+    )
+
+    asyncio.run(
+        SignerClient.create_market_order(
+            client,
+            market_index=2,
+            client_order_index=2,
+            base_amount=100,
+            avg_execution_price=1_400_000,
+            is_ask=True,
+            nonce=12,
+            api_key_index=3,
+        )
+    )
+
+    first_call = client.create_order.await_args_list[0]
+    second_call = client.create_order.await_args_list[1]
+
+    assert first_call.kwargs["price"] == 1_400_000
+    assert second_call.kwargs["price"] == 1_400_000
+
+
+def test_create_sl_market_order_sets_price_to_trigger_price():
+    client = object.__new__(SignerClient)
+    client.create_order = AsyncMock(return_value=(None, None, None))
+
+    asyncio.run(
+        SignerClient.create_sl_market_order(
+            client,
+            market_index=9,
+            client_order_index=123,
+            base_amount=456,
+            trigger_price=789_000,
+            is_ask=True,
+            reduce_only=True,
+            nonce=15,
+            api_key_index=2,
+        )
+    )
+
+    call = client.create_order.await_args
+    assert call.args[0] == 9
+    assert call.args[1] == 123
+    assert call.args[2] == 456
+    assert call.args[3] == 789_000
+    assert call.args[4] is True
+    assert call.args[5] == SignerClient.ORDER_TYPE_STOP_LOSS
+    assert call.args[6] == SignerClient.ORDER_TIME_IN_FORCE_IMMEDIATE_OR_CANCEL
+    assert call.args[7] is True
+    assert call.args[8] == 789_000
+    assert call.args[9] == SignerClient.DEFAULT_IOC_EXPIRY
+    assert call.kwargs["nonce"] == 15
+    assert call.kwargs["api_key_index"] == 2
+
+
+def test_get_market_index_symbol_map_includes_perps_and_spot():
+    class Market:
+        def __init__(self, market_id, symbol):
+            self.market_id = market_id
+            self.symbol = symbol
+
+    class Details:
+        order_book_details = [Market(0, "ETH"), Market(24, "BTC")]
+        spot_order_book_details = [Market(2048, "ETH-USDC")]
+
+    class FakeOrderApi:
+        async def order_book_details(self):
+            return Details()
+
+    client = object.__new__(SignerClient)
+    client.order_api = FakeOrderApi()
+
+    mapping = asyncio.run(SignerClient.get_market_index_symbol_map(client))
+    assert mapping[0] == "ETH"
+    assert mapping[24] == "BTC"
+    assert mapping[2048] == "ETH-USDC"
+
+
+def test_get_market_index_for_symbol_is_case_insensitive():
+    client = object.__new__(SignerClient)
+
+    async def fake_map(**kwargs):
+        return {0: "ETH", 24: "BTC", 2048: "ETH-USDC"}
+
+    client.get_market_index_symbol_map = fake_map
+
+    assert asyncio.run(SignerClient.get_market_index_for_symbol(client, "eth")) == 0
+    assert asyncio.run(SignerClient.get_market_index_for_symbol(client, "ETH-USDC")) == 2048
+    assert asyncio.run(SignerClient.get_market_index_for_symbol(client, "SOL")) is None
+
+
+def test_sign_create_grouped_orders_forwards_grouping_type_and_order_count():
+    """#72 regression: sign_create_grouped_orders must forward grouping_type and every
+    order in the array to SignCreateGroupedOrders unchanged."""
+    from lighter.signer_client import CreateOrderTxReq
+
+    captured = {}
+
+    class FakeSigner:
+        def SignCreateGroupedOrders(self, grouping_type, orders_arr, count, nonce, api_key_index, account_index):
+            captured["grouping_type"] = grouping_type
+            captured["count"] = count
+            captured["nonce"] = nonce
+            captured["api_key_index"] = api_key_index
+            # return a SignedTxResponse-like object with null fields so decode works
+            import ctypes
+            from lighter.signer_client import SignedTxResponse
+            r = SignedTxResponse()
+            r.txType = 7
+            r.txInfo = None
+            r.txHash = None
+            r.messageToSign = None
+            r.err = None
+            return r
+
+    client = object.__new__(SignerClient)
+    client.signer = FakeSigner()
+    client.account_index = 5
+
+    orders = [CreateOrderTxReq(), CreateOrderTxReq()]
+
+    original = SignerClient._SignerClient__decode_tx_info
+    SignerClient._SignerClient__decode_tx_info = staticmethod(
+        lambda result: (result.txType, None, None, None)
+    )
+    try:
+        SignerClient.sign_create_grouped_orders(
+            client,
+            grouping_type=SignerClient.GROUPING_TYPE_ONE_CANCELS_THE_OTHER,
+            orders=orders,
+            nonce=42,
+            api_key_index=7,
+        )
+    finally:
+        SignerClient._SignerClient__decode_tx_info = original
+
+    assert captured["grouping_type"] == SignerClient.GROUPING_TYPE_ONE_CANCELS_THE_OTHER
+    assert captured["count"] == 2
+    assert captured["nonce"] == 42
+    assert captured["api_key_index"] == 7
+
+
+def test_process_api_key_and_nonce_handles_none_response_without_attribute_error():
+    class FakeNonceManager:
+        def __init__(self):
+            self.failure_acks = 0
+
+        def next_nonce(self):
+            return 3, 77
+
+        def acknowledge_failure(self, api_key_index):
+            self.failure_acks += 1
+
+        def hard_refresh_nonce(self, api_key_index):
+            pass
+
+    class DummyClient:
+        def __init__(self):
+            self.nonce_manager = FakeNonceManager()
+
+    @signer_client_module.process_api_key_and_nonce
+    async def fake_create(self, nonce=SignerClient.DEFAULT_NONCE, api_key_index=SignerClient.DEFAULT_API_KEY_INDEX):
+        return None, None, "some signer error"
+
+    client = DummyClient()
+    created_tx, ret, err = asyncio.run(fake_create(client))
+
+    assert created_tx is None
+    assert ret is None
+    assert err == "some signer error"
+    assert client.nonce_manager.failure_acks == 1
+
+
+def test_create_sl_market_order_limited_slippage_uses_adjusted_price():
+    client = object.__new__(SignerClient)
+    client.create_sl_order = AsyncMock(return_value=(None, None, None))
+
+    asyncio.run(
+        SignerClient.create_sl_market_order_limited_slippage(
+            client,
+            market_index=7,
+            client_order_index=99,
+            base_amount=1000,
+            trigger_price=1_000_000,
+            max_slippage=0.01,
+            is_ask=False,
+            reduce_only=True,
+            ideal_price=1_000_000,
+            nonce=4,
+            api_key_index=6,
+        )
+    )
+
+    call = client.create_sl_order.await_args
+    assert call.kwargs["price"] == 1_010_000
+    assert call.kwargs["trigger_price"] == 1_000_000
+
+
+def test_create_tp_market_order_limited_slippage_uses_adjusted_price():
+    client = object.__new__(SignerClient)
+    client.create_tp_order = AsyncMock(return_value=(None, None, None))
+
+    asyncio.run(
+        SignerClient.create_tp_market_order_limited_slippage(
+            client,
+            market_index=7,
+            client_order_index=100,
+            base_amount=1000,
+            trigger_price=1_000_000,
+            max_slippage=0.02,
+            is_ask=True,
+            reduce_only=True,
+            ideal_price=1_000_000,
+            nonce=5,
+            api_key_index=6,
+        )
+    )
+
+    call = client.create_tp_order.await_args
+    assert call.kwargs["price"] == 980_000
+    assert call.kwargs["trigger_price"] == 1_000_000
+
+
+def test_account_position_parses_optional_leverage_field():
+    parsed = AccountPosition.from_dict(
+        {
+            "market_id": 0,
+            "symbol": "ETH",
+            "initial_margin_fraction": "1000",
+            "open_order_count": 1,
+            "pending_order_count": 1,
+            "position_tied_order_count": 0,
+            "sign": 1,
+            "position": "1.0",
+            "avg_entry_price": "2000",
+            "position_value": "2000",
+            "unrealized_pnl": "10",
+            "realized_pnl": "0",
+            "liquidation_price": "1500",
+            "total_funding_paid_out": "0",
+            "margin_mode": 1,
+            "leverage": 20,
+            "allocated_margin": "100",
+            "total_discount": "0",
+        }
+    )
+
+    assert parsed is not None
+    assert parsed.leverage == 20
+
+
+def test_signer_client_applies_proxy_to_configuration():
+    captured_config = None
+
+    class DummyApiClient:
+        async def close(self):
+            return None
+
+    class DummyNonceManager:
+        def next_nonce(self):
+            return 255, 1
+
+    class FakeSigner:
+        def CreateClient(self, *args):
+            return None
+
+    def fake_api_client_factory(configuration):
+        nonlocal captured_config
+        captured_config = configuration
+        return DummyApiClient()
+
+    with patch("lighter.signer_client.get_signer", return_value=(FakeSigner(), None)), patch(
+        "lighter.signer_client.nonce_manager.nonce_manager_factory",
+        return_value=DummyNonceManager(),
+    ), patch("lighter.signer_client.lighter.ApiClient", side_effect=fake_api_client_factory), patch(
+        "lighter.signer_client.lighter.TransactionApi", return_value=object()
+    ), patch("lighter.signer_client.lighter.OrderApi", return_value=object()), patch(
+        "lighter.signer_client.lighter.AccountApi", return_value=object()
+    ):
+        SignerClient(
+            url="https://testnet.zklighter.elliot.ai",
+            account_index=1,
+            api_private_keys={2: "abc"},
+            proxy="http://127.0.0.1:8080",
+            proxy_headers={"Proxy-Authorization": "Basic xyz"},
+        )
+
+    assert captured_config is not None
+    assert captured_config.proxy == "http://127.0.0.1:8080"
+    assert captured_config.proxy_headers == {"Proxy-Authorization": "Basic xyz"}
+
+
+def test_fetch_order_checks_active_then_inactive_orders():
+    class OrderObj:
+        def __init__(self, order_id, client_order_index):
+            self.order_id = order_id
+            self.client_order_index = client_order_index
+
+    class OrdersResp:
+        def __init__(self, orders):
+            self.orders = orders
+
+    class FakeOrderApi:
+        async def account_active_orders(self, **kwargs):
+            return OrdersResp([OrderObj("a", 1)])
+
+        async def account_inactive_orders(self, **kwargs):
+            return OrdersResp([OrderObj("b", 2)])
+
+    client = object.__new__(SignerClient)
+    client.account_index = 77
+    client.order_api = FakeOrderApi()
+
+    found = asyncio.run(SignerClient.fetch_order(client, order_id="b"))
+    assert found is not None
+    assert found.client_order_index == 2
+
+
+def test_fetch_positions_and_get_leverage_info():
+    class Position:
+        def __init__(self, market_id, initial_margin_fraction, margin_mode):
+            self.market_id = market_id
+            self.initial_margin_fraction = initial_margin_fraction
+            self.margin_mode = margin_mode
+
+    class Account:
+        def __init__(self):
+            self.positions = [Position(0, "500", 1)]
+
+    class AccountsResp:
+        def __init__(self):
+            self.accounts = [Account()]
+
+    class Market:
+        def __init__(self, market_id, min_initial_margin_fraction):
+            self.market_id = market_id
+            self.min_initial_margin_fraction = min_initial_margin_fraction
+
+    class MarketResp:
+        def __init__(self):
+            self.order_book_details = [Market(0, "250")]
+
+    class FakeAccountApi:
+        async def account(self, **kwargs):
+            return AccountsResp()
+
+    class FakeOrderApi:
+        async def order_book_details(self):
+            return MarketResp()
+
+    client = object.__new__(SignerClient)
+    client.account_index = 7
+    client.account_api = FakeAccountApi()
+    client.order_api = FakeOrderApi()
+
+    positions = asyncio.run(SignerClient.fetch_positions(client))
+    assert len(positions) == 1
+
+    leverage = asyncio.run(SignerClient.get_leverage_info(client))
+    assert 0 in leverage
+    assert leverage[0]["leverage"] == 20
+    assert leverage[0]["max_leverage"] == 40
+    assert leverage[0]["margin_mode"] == 1
+
+
+def test_trade_model_allows_nullable_margin_fraction_fields():
+    trade = Trade.from_dict(
+        {
+            "trade_id": 1,
+            "tx_hash": "0xabc",
+            "type": "trade",
+            "market_id": 0,
+            "size": "1",
+            "price": "2000",
+            "usd_amount": "2000",
+            "ask_id": 10,
+            "bid_id": 11,
+            "ask_client_id": 12,
+            "bid_client_id": 13,
+            "ask_account_id": 14,
+            "bid_account_id": 15,
+            "is_maker_ask": True,
+            "block_height": 16,
+            "timestamp": 17,
+            "taker_fee": 18,
+            "taker_position_size_before": "0",
+            "taker_entry_quote_before": "0",
+            "taker_initial_margin_fraction_before": None,
+            "taker_position_sign_changed": False,
+            "maker_fee": 19,
+            "maker_position_size_before": "0",
+            "maker_entry_quote_before": "0",
+            "maker_initial_margin_fraction_before": None,
+            "maker_position_sign_changed": False,
+            "transaction_time": 20,
+            "ask_account_pnl": "0",
+            "bid_account_pnl": "0",
+        }
+    )
+
+    assert trade is not None
+    assert trade.taker_initial_margin_fraction_before is None
+    assert trade.maker_initial_margin_fraction_before is None

--- a/test/test_issue_regressions.py
+++ b/test/test_issue_regressions.py
@@ -141,6 +141,7 @@ def test_linux_aarch64_loads_arm_shared_library():
             self.CreateAuthToken = FakeFunction()
             self.SignUpdateMargin = FakeFunction()
             self.SignApproveIntegrator = FakeFunction()
+            self.Free = FakeFunction()
 
     def fake_cdll(path):
         nonlocal captured_path


### PR DESCRIPTION
## PR Description

### Summary
This PR hardens the Python SDK around signer loading, request compatibility, typed model parsing, and websocket behavior, and adds regression coverage for the reported issue set.

### What changed
- normalize `l1_address` inputs before account lookups
- require `market_id` for `account_active_orders` and keep request serialization aligned with server expectations
- default grouped-order `aggregate` to `false` when omitted
- infer chain ID more reliably and isolate signer library loading per client
- support Linux `aarch64` / ARM shared library resolution
- propagate proxy and proxy header configuration into REST clients
- normalize auth token expiry and order expiry handling
- add nullable parsing for trade margin fields returned as `null`
- add optional `leverage` parsing on account positions
- improve websocket keepalive, ping/pong handling, and order book gap detection
- source `__version__` from installed package metadata
- raise the `urllib3` minimum version to `1.26.18` for a safer dependency floor while keeping Python 3.8 compatibility
- add regression tests covering the issue fixes

### Validation
- rebased onto upstream `main` / `v1.0.7`
- local test suite passes: `36 passed`
- PR branch updated and force-pushed after rebase conflict resolution

### Compatibility notes
This PR is primarily issue-fix oriented, but it is not strictly zero-break:

- the `Candle` model no longer exposes uppercase duplicate fields such as `O`, `H`, `L`, `C`, and `V`
- `account_active_orders` now enforces `market_id` at the SDK boundary
- direct consumers of internal `lighter.signer_client.get_signer()` behavior may notice its return shape change