### PR TITLE
fix: resolve duplicate field names in Candle model dropping lowercase OHLCV

### DIFF
--- a/lighter/models/candle.py
+++ b/lighter/models/candle.py
@@ -31,12 +31,12 @@ class Candle(BaseModel):
     h: Union[StrictFloat, StrictInt] = Field(description=" high")
     l: Union[StrictFloat, StrictInt] = Field(description=" low")
     c: Union[StrictFloat, StrictInt] = Field(description=" close")
-    o: Union[StrictFloat, StrictInt] = Field(description=" open_raw", alias="O")
-    h: Union[StrictFloat, StrictInt] = Field(description=" high_raw", alias="H")
-    l: Union[StrictFloat, StrictInt] = Field(description=" low_raw", alias="L")
-    c: Union[StrictFloat, StrictInt] = Field(description=" close_raw", alias="C")
+    open_raw: Union[StrictFloat, StrictInt] = Field(description=" open_raw", alias="O")
+    high_raw: Union[StrictFloat, StrictInt] = Field(description=" high_raw", alias="H")
+    low_raw: Union[StrictFloat, StrictInt] = Field(description=" low_raw", alias="L")
+    close_raw: Union[StrictFloat, StrictInt] = Field(description=" close_raw", alias="C")
     v: Union[StrictFloat, StrictInt] = Field(description=" volume0")
-    v: Union[StrictFloat, StrictInt] = Field(description=" volume1", alias="V")
+    volume_raw: Union[StrictFloat, StrictInt] = Field(description=" volume1", alias="V")
     i: StrictInt = Field(description=" last_trade_id")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["t", "o", "h", "l", "c", "O", "H", "L", "C", "v", "V", "i"]
@@ -104,12 +104,12 @@ class Candle(BaseModel):
             "h": obj.get("h"),
             "l": obj.get("l"),
             "c": obj.get("c"),
-            "O": obj.get("O"),
-            "H": obj.get("H"),
-            "L": obj.get("L"),
-            "C": obj.get("C"),
+            "open_raw": obj.get("O"),
+            "high_raw": obj.get("H"),
+            "low_raw": obj.get("L"),
+            "close_raw": obj.get("C"),
             "v": obj.get("v"),
-            "V": obj.get("V"),
+            "volume_raw": obj.get("V"),
             "i": obj.get("i")
         })
         # store additional fields in additional_properties


### PR DESCRIPTION
## Summary

Fixes a codegen bug in the `Candle` Pydantic model where the OpenAPI generator mapped both lowercase (`o`, `h`, `l`, `c`, `v`) and uppercase (`O`, `H`, `L`, `C`, `V`) JSON properties to the **same** Python attribute names using `alias=`. In Python, each redefinition in a class body silently clobbers the previous one, so only the uppercase-aliased fields survived — the lowercase `o`/`h`/`l`/`c`/`v` fields were effectively dropped from the model.

**Before:** `Candle.from_dict(...)` silently loses lowercase OHLCV data. `to_dict()` only outputs the uppercase fields.

**After:** Each field has a unique Python attribute name. Uppercase fields use descriptive names (`open_raw`, `high_raw`, `low_raw`, `close_raw`, `volume_raw`) with `alias=` preserving the JSON key mapping (`O`, `H`, `L`, `C`, `V`). This matches the naming used in `DetailedCandlestick` and the original `Candlestick` model before the v1.0.3 API key shortening.

The `from_dict` method is updated to pass Python field names (not aliases) to `model_construct`, and `to_dict` continues to use `model_dump(by_alias=True)` so JSON serialization is unchanged.

## Review & Testing Checklist for Human

- [ ] **Breaking change for SDK consumers**: Anyone accessing the raw OHLCV via attribute (e.g. `candle.o` expecting the uppercase/raw value) will now need `candle.open_raw`. Verify downstream usage in any internal tools or examples that consume `Candle` objects directly by attribute name.
- [ ] **Round-trip fidelity**: Confirm `Candle.from_dict(api_response).to_dict()` preserves all 12 keys (`t`, `o`, `h`, `l`, `c`, `O`, `H`, `L`, `C`, `v`, `V`, `i`) against a live API response.
- [ ] **Re-running codegen**: This is a hand-edit of generated code. Re-running `openapi-generator` will reintroduce the bug. Consider updating the generator config or adding a post-gen fixup if you regenerate models in the future.

### Notes
- The collision only affects the `Candle` model — no other models in the spec have case-insensitive property name collisions.
- The `__properties` class var was intentionally left unchanged since it tracks JSON property names (used for `additional_properties` filtering), not Python attribute names.

Link to Devin session: https://app.devin.ai/sessions/d07d73b9064843faa750d7cf69f29c0a
Requested by: @kutay25
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elliottech/lighter-python/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
