### PR TITLE
[fix] correct duplicate field names in candle model

### DIFF
--- a/lighter/models/candle.py
+++ b/lighter/models/candle.py
@@ -31,12 +31,12 @@ class Candle(BaseModel):
     h: Union[StrictFloat, StrictInt] = Field(description=" high")
     l: Union[StrictFloat, StrictInt] = Field(description=" low")
     c: Union[StrictFloat, StrictInt] = Field(description=" close")
-    o: Union[StrictFloat, StrictInt] = Field(description=" open_raw", alias="O")
-    h: Union[StrictFloat, StrictInt] = Field(description=" high_raw", alias="H")
-    l: Union[StrictFloat, StrictInt] = Field(description=" low_raw", alias="L")
-    c: Union[StrictFloat, StrictInt] = Field(description=" close_raw", alias="C")
+    O: Union[StrictFloat, StrictInt] = Field(description=" open_raw", alias="O")
+    H: Union[StrictFloat, StrictInt] = Field(description=" high_raw", alias="H")
+    L: Union[StrictFloat, StrictInt] = Field(description=" low_raw", alias="L")
+    C: Union[StrictFloat, StrictInt] = Field(description=" close_raw", alias="C")
     v: Union[StrictFloat, StrictInt] = Field(description=" volume0")
-    v: Union[StrictFloat, StrictInt] = Field(description=" volume1", alias="V")
+    V: Union[StrictFloat, StrictInt] = Field(description=" volume1", alias="V")
     i: StrictInt = Field(description=" last_trade_id")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["t", "o", "h", "l", "c", "O", "H", "L", "C", "v", "V", "i"]


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/elliottech/lighter-python/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
