### PR TITLE
Remove obsolete urllib3 upper bound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3
 pydantic >= 2
 typing-extensions >= 4.7.1
 aiohttp >= 3.0.0

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ NAME = "lighter-sdk"
 VERSION = "1.1.1"
 PYTHON_REQUIRES = ">=3.7"
 REQUIRES = [
-    "urllib3 >= 1.25.3, < 2.1.0",
+    "urllib3 >= 1.25.3",
     "python-dateutil",
     "aiohttp >= 3.0.0",
     "aiohttp-retry >= 2.8.3",


### PR DESCRIPTION
## Summary
- remove the obsolete `urllib3<2.1.0` cap from setuptools metadata
- align `requirements.txt` with the already-unbounded Poetry dependency declaration
- allow current patched urllib3 releases to resolve

Closes #21.

## Validation
- built the wheel on Python 3.13
- installed it with `urllib3==2.7.0` and the downstream constraint set
- `python -m pip check`
- `python -m pytest -q` (`62 passed`)
- `pip-audit` (`No known vulnerabilities found`)
