### PR TITLE
Make normal signing ~30× faster; add opt-in batching

### DIFF
--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -6,6 +6,8 @@ import json
 import platform
 import logging
 import os
+import struct
+import threading
 import time
 from typing import Dict, List, Optional, Union, Tuple, Any
 
@@ -57,7 +59,23 @@ class SignedTxResponse(ctypes.Structure):
     ]
 
 
+class SignedTxBatchResponse(ctypes.Structure):
+    _fields_ = [
+        ('data', ctypes.c_void_p),
+        ('length', ctypes.c_int64),
+        ('err', ctypes.c_void_p),
+    ]
+
+
+_SIGNED_TX_BATCH_PREFIX = struct.Struct('<I')
+_SIGNED_TX_BATCH_HEADER = struct.Struct('<B3xIII')
+_MAX_CREATE_ORDER_BATCH = 10_000
+_MAX_PREPARED_NONCES = 10_000
+_MAX_SIGNER_NONCE = (1 << 63) - 1
+
+
 __signer = None
+__signer_lock = threading.Lock()
 __native_free = None
 __native_allocator = None
 
@@ -131,7 +149,78 @@ def decode_and_free(ptr: Any) -> Optional[str]:
         free_pointer(ptr)
 
 
+def decode_signed_tx_batch(data: bytes):
+    if len(data) < _SIGNED_TX_BATCH_PREFIX.size:
+        raise ValueError("packed signer response is missing its count")
+
+    count, = _SIGNED_TX_BATCH_PREFIX.unpack_from(data)
+    if count > _MAX_CREATE_ORDER_BATCH:
+        raise ValueError(
+            "packed signer response count exceeds "
+            f"{_MAX_CREATE_ORDER_BATCH}"
+        )
+
+    offset = _SIGNED_TX_BATCH_PREFIX.size
+    decoded = []
+    for _ in range(count):
+        if offset + _SIGNED_TX_BATCH_HEADER.size > len(data):
+            raise ValueError("packed signer response has a truncated header")
+        tx_type, tx_info_length, tx_hash_length, error_length = (
+            _SIGNED_TX_BATCH_HEADER.unpack_from(data, offset)
+        )
+        offset += _SIGNED_TX_BATCH_HEADER.size
+        payload_length = tx_info_length + tx_hash_length + error_length
+        if payload_length > len(data) - offset:
+            raise ValueError("packed signer response has a truncated payload")
+
+        tx_info_end = offset + tx_info_length
+        tx_hash_end = tx_info_end + tx_hash_length
+        error_end = tx_hash_end + error_length
+        tx_info = data[offset:tx_info_end].decode('utf-8') or None
+        tx_hash = data[tx_info_end:tx_hash_end].decode('utf-8') or None
+        error = data[tx_hash_end:error_end].decode('utf-8') or None
+        offset = error_end
+        if error:
+            decoded.append((None, None, None, error))
+        else:
+            decoded.append((tx_type, tx_info, tx_hash, None))
+
+    if offset != len(data):
+        raise ValueError("packed signer response has trailing data")
+    return decoded
+
+
+def _copy_and_free_signed_tx_batch(response: SignedTxBatchResponse):
+    try:
+        error = (
+            ctypes.string_at(response.err).decode('utf-8')
+            if response.err else None
+        )
+        packed = (
+            ctypes.string_at(response.data, response.length)
+            if response.data else b''
+        )
+    finally:
+        free_pointer(response.data)
+        free_pointer(response.err)
+    return packed, error
+
+
+def _enable_stack_bound_cache(signer) -> bool:
+    """Enable the optional private-Go-hook callback optimization."""
+    stack_bound_cache = getattr(signer, "FastEnableStackBoundCache", None)
+    if stack_bound_cache is None:
+        return False
+    stack_bound_cache.argtypes = []
+    stack_bound_cache.restype = ctypes.c_int
+    return bool(stack_bound_cache())
+
+
 def __populate_shared_library_functions(signer):
+    if not _enable_stack_bound_cache(signer):
+        logging.getLogger(__name__).debug(
+            "native signer stack-bound cache is unavailable")
+
     signer.GenerateAPIKey.argtypes = []
     signer.GenerateAPIKey.restype = ApiKeyResponse
 
@@ -147,6 +236,19 @@ def __populate_shared_library_functions(signer):
     signer.SignCreateOrder.argtypes = [ctypes.c_int, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
                                             ctypes.c_int, ctypes.c_int, ctypes.c_longlong, ctypes.c_longlong, ctypes.c_int, ctypes.c_int, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
     signer.SignCreateOrder.restype = SignedTxResponse
+
+    if hasattr(signer, "SignCreateOrdersBatch"):
+        signer.SignCreateOrdersBatch.argtypes = [
+            ctypes.POINTER(CreateOrderTxReq), ctypes.c_int,
+            ctypes.c_longlong, ctypes.c_int, ctypes.c_int,
+            ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8,
+            ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong,
+        ]
+        signer.SignCreateOrdersBatch.restype = SignedTxBatchResponse
+
+    if hasattr(signer, "PrepareSignerNonces"):
+        signer.PrepareSignerNonces.argtypes = [ctypes.c_int]
+        signer.PrepareSignerNonces.restype = ctypes.c_void_p
 
     signer.SignCreateGroupedOrders.argtypes = [ctypes.c_uint8, ctypes.POINTER(CreateOrderTxReq), ctypes.c_int, ctypes.c_longlong, ctypes.c_int, ctypes.c_int, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_uint8, ctypes.c_longlong, ctypes.c_int, ctypes.c_longlong]
     signer.SignCreateGroupedOrders.restype = SignedTxResponse
@@ -213,14 +315,18 @@ def __populate_shared_library_functions(signer):
 
 
 def get_signer():
-    # check if singleton exists already
     global __signer
     if __signer is not None:
         return __signer
 
-    # create shared library & populate methods
-    __signer = __get_shared_library()
-    __populate_shared_library_functions(__signer)
+    # Publish only a fully configured library. This prevents another thread
+    # from calling a function while ctypes signatures and the runtime hook are
+    # still being initialized.
+    with __signer_lock:
+        if __signer is None:
+            signer = __get_shared_library()
+            __populate_shared_library_functions(signer)
+            __signer = signer
     return __signer
 
 
@@ -546,6 +652,111 @@ class SignerClient:
             api_key_index,
             self.account_index,
         ))
+
+    def prepare_signer_nonces(self, count: int) -> None:
+        """Precompute one-use Schnorr commitments for a later signing burst.
+
+        Prepared nonces are held in a process-global in-memory pool until any
+        signer consumes them. They must not be persisted, serialized, or
+        shared across a process fork.
+        """
+        if count < 0 or count > _MAX_PREPARED_NONCES:
+            raise ValueError(
+                "prepared nonce count must be between 0 and "
+                f"{_MAX_PREPARED_NONCES}"
+            )
+        prepare = getattr(self.signer, "PrepareSignerNonces", None)
+        if prepare is None:
+            raise RuntimeError(
+                "the loaded signer does not support prepared nonces"
+            )
+        error = decode_and_free(prepare(count))
+        if error:
+            raise RuntimeError(error)
+
+    def sign_create_orders_batch(
+            self,
+            orders: List[CreateOrderTxReq],
+            first_nonce: int,
+            *,
+            integrator_account_index: int = 0,
+            integrator_taker_fee: int = 0,
+            integrator_maker_fee: int = 0,
+            self_trade_behavior_mode: int = 0,
+            self_trade_equality_mode: int = 0,
+            skip_nonce: int = SKIP_NONCE_OFF,
+            api_key_index: int = DEFAULT_API_KEY_INDEX
+    ):
+        """Sign independent create-order transactions with consecutive
+        nonces.
+        """
+        if not orders:
+            return []
+        if len(orders) > _MAX_CREATE_ORDER_BATCH:
+            raise ValueError(
+                "create-order batch cannot exceed "
+                f"{_MAX_CREATE_ORDER_BATCH} orders"
+            )
+        if first_nonce < 0:
+            raise ValueError(
+                "batch signing requires an explicit non-negative first nonce; "
+                "it does not perform network I/O"
+            )
+        if first_nonce > _MAX_SIGNER_NONCE - (len(orders) - 1):
+            raise ValueError("create-order batch nonce range overflows int64")
+
+        batch_signer = getattr(self.signer, "SignCreateOrdersBatch", None)
+        if batch_signer is None:
+            return [
+                self.sign_create_order(
+                    order.MarketIndex,
+                    order.ClientOrderIndex,
+                    order.BaseAmount,
+                    order.Price,
+                    order.IsAsk,
+                    order.Type,
+                    order.TimeInForce,
+                    order.ReduceOnly,
+                    order.TriggerPrice,
+                    order.OrderExpiry,
+                    integrator_account_index=integrator_account_index,
+                    integrator_taker_fee=integrator_taker_fee,
+                    integrator_maker_fee=integrator_maker_fee,
+                    self_trade_behavior_mode=self_trade_behavior_mode,
+                    self_trade_equality_mode=self_trade_equality_mode,
+                    skip_nonce=skip_nonce,
+                    nonce=first_nonce + index,
+                    api_key_index=api_key_index,
+                )
+                for index, order in enumerate(orders)
+            ]
+
+        orders_type = CreateOrderTxReq * len(orders)
+        orders_array = orders_type(*orders)
+        response = batch_signer(
+            orders_array,
+            len(orders),
+            integrator_account_index,
+            integrator_taker_fee,
+            integrator_maker_fee,
+            self_trade_behavior_mode,
+            self_trade_equality_mode,
+            skip_nonce,
+            first_nonce,
+            api_key_index,
+            self.account_index,
+        )
+        packed, error = _copy_and_free_signed_tx_batch(response)
+
+        if error:
+            raise RuntimeError(error)
+        decoded = decode_signed_tx_batch(packed)
+        if len(decoded) != len(orders):
+            raise RuntimeError(
+                "native signer returned "
+                f"{len(decoded)} results for {len(orders)} orders"
+            )
+        return decoded
 
     def sign_create_grouped_orders(
             self,

--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -58,6 +58,8 @@ class SignedTxResponse(ctypes.Structure):
 
 
 __signer = None
+__native_free = None
+__native_allocator = None
 
 
 def __get_shared_library():
@@ -87,20 +89,46 @@ def __get_shared_library():
         )
 
 
+def __get_native_free():
+    global __native_free, __native_allocator
+    if __native_free is not None:
+        return __native_free
+
+    if os.name == "posix":
+        # Go's C.CString allocates with C.malloc. On POSIX there is one process
+        # allocator, so calling free directly avoids an expensive Python -> Go
+        # transition for every returned string.
+        try:
+            __native_allocator = ctypes.CDLL(None)
+            native_free = __native_allocator.free
+            native_free.argtypes = [ctypes.c_void_p]
+            native_free.restype = None
+            __native_free = native_free
+        except (AttributeError, OSError):
+            __native_free = get_signer().Free
+    else:
+        # Windows can have multiple CRT heaps. Keep using the signer's exported
+        # Free function so allocation and deallocation use the same runtime.
+        __native_free = get_signer().Free
+
+    return __native_free
+
+
+def free_pointer(ptr: Any) -> None:
+    if ptr:
+        __get_native_free()(ptr)
+
+
 def decode_and_free(ptr: Any) -> Optional[str]:
     if not ptr:
         return None
     try:
-        # Read the string from the pointer
-        c_str = ctypes.cast(ptr, ctypes.c_char_p).value
+        c_str = ctypes.string_at(ptr)
         if c_str is not None:
             return c_str.decode('utf-8')
         return None
     finally:
-        # Free the memory using the signer's own Free function to ensure
-        # the same C runtime that allocated the memory also frees it.
-        # This is critical on Windows where different CRTs have separate heaps.
-        __signer.Free(ptr)
+        free_pointer(ptr)
 
 
 def __populate_shared_library_functions(signer):
@@ -376,7 +404,7 @@ class SignerClient:
         err_str = decode_and_free(result.err)
         tx_info_str = decode_and_free(result.txInfo)
         tx_hash_str = decode_and_free(result.txHash)
-        decode_and_free(result.messageToSign)
+        free_pointer(result.messageToSign)
 
         if err_str:
             return None, None, None, err_str

--- a/lighter/signer_client.py
+++ b/lighter/signer_client.py
@@ -32,7 +32,7 @@ class ApiKeyResponse(ctypes.Structure):
 
 class CreateOrderTxReq(ctypes.Structure):
     _fields_ = [
-        ("MarketIndex", ctypes.c_int),
+        ("MarketIndex", ctypes.c_int16),
         ("ClientOrderIndex", ctypes.c_longlong),
         ("BaseAmount", ctypes.c_longlong),
         ("Price", ctypes.c_uint32),

--- a/test/test_signer_client.py
+++ b/test/test_signer_client.py
@@ -1,0 +1,64 @@
+import ctypes
+import unittest
+from unittest import mock
+
+from lighter import signer_client
+
+
+class TestSignerMemoryManagement(unittest.TestCase):
+    def test_decode_and_free_releases_pointer_once(self):
+        value = ctypes.create_string_buffer(b"lighter")
+        pointer = ctypes.addressof(value)
+        native_free = mock.Mock()
+
+        with mock.patch.object(signer_client, "__native_free", native_free):
+            self.assertEqual(signer_client.decode_and_free(pointer), "lighter")
+
+        native_free.assert_called_once_with(pointer)
+
+    def test_decode_and_free_releases_pointer_when_decoding_fails(self):
+        value = ctypes.create_string_buffer(b"\xff")
+        pointer = ctypes.addressof(value)
+        native_free = mock.Mock()
+
+        with mock.patch.object(signer_client, "__native_free", native_free):
+            with self.assertRaises(UnicodeDecodeError):
+                signer_client.decode_and_free(pointer)
+
+        native_free.assert_called_once_with(pointer)
+
+    def test_free_pointer_ignores_null(self):
+        native_free = mock.Mock()
+
+        with mock.patch.object(signer_client, "__native_free", native_free):
+            signer_client.free_pointer(None)
+
+        native_free.assert_not_called()
+
+    def test_windows_uses_signer_allocator(self):
+        signer = mock.Mock()
+        with mock.patch.object(signer_client, "__native_free", None):
+            with mock.patch.object(signer_client.os, "name", "nt"):
+                with mock.patch.object(
+                        signer_client, "get_signer", return_value=signer):
+                    native_free = getattr(
+                        signer_client, "__get_native_free")()
+
+        self.assertIs(native_free, signer.Free)
+
+    def test_posix_falls_back_when_process_allocator_is_unavailable(self):
+        signer = mock.Mock()
+        with mock.patch.object(signer_client, "__native_free", None):
+            with mock.patch.object(signer_client.os, "name", "posix"):
+                with mock.patch.object(
+                        signer_client.ctypes, "CDLL", side_effect=OSError):
+                    with mock.patch.object(
+                            signer_client, "get_signer", return_value=signer):
+                        native_free = getattr(
+                            signer_client, "__get_native_free")()
+
+        self.assertIs(native_free, signer.Free)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_signer_client.py
+++ b/test/test_signer_client.py
@@ -1,11 +1,35 @@
 import ctypes
+import concurrent.futures
+import struct
+import time
 import unittest
 from unittest import mock
 
 from lighter import signer_client
 
 
+def pack_batch_record(tx_type, tx_info=b'', tx_hash=b'', error=b''):
+    return (
+        struct.pack('<B3xIII', tx_type, len(tx_info), len(tx_hash), len(error))
+        + tx_info + tx_hash + error
+    )
+
+
 class TestSignerMemoryManagement(unittest.TestCase):
+    def test_enables_stack_bound_cache_when_supported(self):
+        native = type('Native', (), {})()
+        native.FastEnableStackBoundCache = mock.Mock(return_value=1)
+
+        enabled = signer_client._enable_stack_bound_cache(native)
+
+        self.assertTrue(enabled)
+        self.assertEqual(native.FastEnableStackBoundCache.argtypes, [])
+        self.assertIs(native.FastEnableStackBoundCache.restype, ctypes.c_int)
+        native.FastEnableStackBoundCache.assert_called_once_with()
+
+    def test_stack_bound_cache_is_optional(self):
+        self.assertFalse(signer_client._enable_stack_bound_cache(object()))
+
     def test_decode_and_free_releases_pointer_once(self):
         value = ctypes.create_string_buffer(b"lighter")
         pointer = ctypes.addressof(value)
@@ -58,6 +82,190 @@ class TestSignerMemoryManagement(unittest.TestCase):
                             signer_client, "__get_native_free")()
 
         self.assertIs(native_free, signer.Free)
+
+    def test_get_signer_publishes_one_fully_initialized_instance(self):
+        native = object()
+
+        def populate(_signer):
+            time.sleep(0.01)
+
+        with mock.patch.object(signer_client, "__signer", None):
+            with mock.patch.object(
+                    signer_client, "__get_shared_library",
+                    return_value=native) as load:
+                with mock.patch.object(
+                        signer_client, "__populate_shared_library_functions",
+                        side_effect=populate) as populate_mock:
+                    with concurrent.futures.ThreadPoolExecutor(
+                            max_workers=16) as executor:
+                        results = list(executor.map(
+                            lambda _: signer_client.get_signer(), range(64)))
+
+        self.assertTrue(all(result is native for result in results))
+        load.assert_called_once_with()
+        populate_mock.assert_called_once_with(native)
+
+
+class TestBatchSigning(unittest.TestCase):
+    def test_prepare_signer_nonces(self):
+        native = mock.Mock()
+        native.PrepareSignerNonces.return_value = None
+        client = signer_client.SignerClient.__new__(signer_client.SignerClient)
+        client.signer = native
+
+        client.prepare_signer_nonces(128)
+
+        native.PrepareSignerNonces.assert_called_once_with(128)
+
+    def test_decode_signed_tx_batch(self):
+        packed = (
+            struct.pack('<I', 2)
+            + pack_batch_record(14, b'{"Nonce":7}', b'hash-7')
+            + pack_batch_record(0, error=b'invalid order')
+        )
+
+        self.assertEqual(signer_client.decode_signed_tx_batch(packed), [
+            (14, '{"Nonce":7}', 'hash-7', None),
+            (None, None, None, 'invalid order'),
+        ])
+
+    def test_decode_signed_tx_batch_rejects_truncation(self):
+        packed = struct.pack('<I', 1) + pack_batch_record(
+            14, b'{"Nonce":7}', b'hash-7')[:-1]
+
+        with self.assertRaisesRegex(ValueError, 'truncated payload'):
+            signer_client.decode_signed_tx_batch(packed)
+
+    def test_decode_signed_tx_batch_rejects_trailing_data(self):
+        packed = struct.pack('<I', 0) + b'extra'
+
+        with self.assertRaisesRegex(ValueError, 'trailing data'):
+            signer_client.decode_signed_tx_batch(packed)
+
+    def test_decode_signed_tx_batch_rejects_count_overflow(self):
+        packed = struct.pack('<I', 10_001)
+
+        with self.assertRaisesRegex(ValueError, 'count exceeds'):
+            signer_client.decode_signed_tx_batch(packed)
+
+    def test_sign_create_orders_batch_decodes_one_allocation(self):
+        packed = (
+            struct.pack('<I', 2)
+            + pack_batch_record(14, b'{"Nonce":10}', b'hash-10')
+            + pack_batch_record(14, b'{"Nonce":11}', b'hash-11')
+        )
+
+        class FakeSigner:
+            def __init__(self):
+                self.buffer = ctypes.create_string_buffer(packed)
+                self.arguments = None
+
+            def SignCreateOrdersBatch(self, *arguments):
+                self.arguments = arguments
+                return signer_client.SignedTxBatchResponse(
+                    ctypes.addressof(self.buffer), len(packed), None)
+
+        native = FakeSigner()
+        client = signer_client.SignerClient.__new__(signer_client.SignerClient)
+        client.signer = native
+        client.account_index = 42
+        orders = [
+            signer_client.CreateOrderTxReq(
+                MarketIndex=i,
+                ClientOrderIndex=100 + i,
+                BaseAmount=1_000,
+                Price=2_000,
+                IsAsk=i,
+                Type=0,
+                TimeInForce=1,
+                ReduceOnly=0,
+                TriggerPrice=0,
+                OrderExpiry=-1,
+            )
+            for i in range(2)
+        ]
+
+        with mock.patch.object(signer_client, 'free_pointer') as native_free:
+            result = client.sign_create_orders_batch(
+                orders, 10, api_key_index=3)
+
+        self.assertEqual(result, [
+            (14, '{"Nonce":10}', 'hash-10', None),
+            (14, '{"Nonce":11}', 'hash-11', None),
+        ])
+        self.assertEqual(native.arguments[1], 2)
+        self.assertEqual(native.arguments[8], 10)
+        self.assertEqual(native.arguments[9], 3)
+        self.assertEqual(native.arguments[10], 42)
+        self.assertEqual(native.arguments[0][1].ClientOrderIndex, 101)
+        self.assertEqual(native_free.call_count, 2)
+
+    def test_sign_create_orders_batch_falls_back_for_old_signer(self):
+        client = signer_client.SignerClient.__new__(signer_client.SignerClient)
+        client.signer = object()
+        client.account_index = 42
+        orders = [
+            signer_client.CreateOrderTxReq(),
+            signer_client.CreateOrderTxReq(),
+        ]
+
+        with mock.patch.object(
+                client,
+                'sign_create_order',
+                return_value=(14, '{}', 'hash', None)
+        ) as sign_one:
+            result = client.sign_create_orders_batch(orders, 20)
+
+        self.assertEqual(len(result), 2)
+        self.assertEqual(sign_one.call_args_list[0].kwargs['nonce'], 20)
+        self.assertEqual(sign_one.call_args_list[1].kwargs['nonce'], 21)
+
+    def test_sign_create_orders_batch_rejects_default_nonce_before_fallback(self):
+        client = signer_client.SignerClient.__new__(signer_client.SignerClient)
+        client.signer = object()
+        orders = [signer_client.CreateOrderTxReq()]
+
+        with mock.patch.object(client, 'sign_create_order') as sign_one:
+            with self.assertRaisesRegex(ValueError, 'explicit non-negative'):
+                client.sign_create_orders_batch(orders, -1)
+
+        sign_one.assert_not_called()
+
+    def test_sign_create_orders_batch_rejects_nonce_overflow(self):
+        client = signer_client.SignerClient.__new__(signer_client.SignerClient)
+        client.signer = object()
+        orders = [
+            signer_client.CreateOrderTxReq(),
+            signer_client.CreateOrderTxReq(),
+        ]
+
+        with self.assertRaisesRegex(ValueError, 'overflows int64'):
+            client.sign_create_orders_batch(orders, (1 << 63) - 1)
+
+    def test_sign_create_orders_batch_rejects_short_native_response(self):
+        packed = struct.pack('<I', 1) + pack_batch_record(
+            14, b'{"Nonce":10}', b'hash-10')
+
+        class FakeSigner:
+            def __init__(self):
+                self.buffer = ctypes.create_string_buffer(packed)
+
+            def SignCreateOrdersBatch(self, *_arguments):
+                return signer_client.SignedTxBatchResponse(
+                    ctypes.addressof(self.buffer), len(packed), None)
+
+        client = signer_client.SignerClient.__new__(signer_client.SignerClient)
+        client.signer = FakeSigner()
+        client.account_index = 42
+        orders = [
+            signer_client.CreateOrderTxReq(),
+            signer_client.CreateOrderTxReq(),
+        ]
+
+        with mock.patch.object(signer_client, 'free_pointer'):
+            with self.assertRaisesRegex(
+                    RuntimeError, '1 results for 2 orders'):
+                client.sign_create_orders_batch(orders, 10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Result: ~30× faster normal `sign_create_order`

**Normal single-order latency: 1.95–2.02 ms → 63.9 µs**

**Sequential signing throughput: roughly 500 → 15,700 orders/sec**

**That is approximately 96.7% less latency without changing the public API.**

This is the ordinary one-order-at-a-time public API. It requires **no batching and no prepared nonces**. The normal-path speedup is the purpose of this PR; the explicit batch API is a secondary, opt-in improvement.

The 1.95–2.02 ms baseline is the original warm end-to-end caller measurement on this host. The 63.9 µs result is the public Python signing call with the linked Go and Poseidon changes over 7 × 1,000 sequential orders. Against the currently bundled signer's directly measured 1,644 µs public Python path, it is still 25.7× faster.

## Summary

Speed up the ordinary single-order Python signing path, while remaining compatible with older packaged signer binaries.

- free Go `C.CString` results directly through the process allocator on POSIX, avoiding extra Python-to-Go callbacks
- keep exported-Go `Free` on Windows, where allocation can cross CRT heaps
- enable the linked Go signer's optional stack-bound callback cache when present
- publish the signer singleton only after all ctypes signatures and runtime hooks are configured
- preserve graceful fallback when an older binary lacks the new exports

With the currently bundled Linux signer, changing only response cleanup reduced the public single-order path from 1,644 µs/order to 816.5 µs/order (median, 5 × 500 orders). With the linked Go and Poseidon PRs, the normal public call measured 63.9 µs/order (median, 7 × 1,000 orders), or about 15.7k orders/sec on the same Intel Xeon E-2286G host.

> [!IMPORTANT]
> The largest C-to-Go boundary reduction in the linked Go PR requires the private Go `_cgo_getstackbound` hook. It is unsupported runtime internals, version-gated, and must be revalidated before upgrading the Go toolchain. This Python wrapper treats it as optional and continues to work when the export is absent or disabled.

## Secondary: explicit batching and prepared nonces

The new `sign_create_orders_batch` method is opt-in. A normal `sign_create_order` call does **not** batch. The method uses one packed native response allocation, validates the explicit nonce range before either the native or legacy fallback path, and checks that the native result count matches the request count.

On batches of 1,000 orders:

| Mode | Median | Throughput |
|---|---:|---:|
| normal single-order calls | 63.9 µs/order | 15.7k/sec |
| prepared single-order calls | 14.8 µs/order | 67.7k/sec |
| normal explicit batch | 10.5 µs/order | 94.9k/sec |
| prepared explicit batch | 3.24 µs/order | 308k/sec |

Prepared nonces are held in a process-global, in-memory pool by the linked Go signer. They are single-use and must not be persisted, serialized, or shared across a fork.

This PR also fixes the existing `CreateOrderTxReq.MarketIndex` ctypes field from 32-bit to the native ABI's 16-bit width in a separate commit.

## Packaging / merge order

No generated signer binaries are changed in this draft. Please merge/tag the Poseidon PR, update/merge the Go signer PR, regenerate all platform binaries, and then merge this wrapper PR.

- Poseidon speedup: [elliottech/poseidon_crypto#38](https://github.com/elliottech/poseidon_crypto/pull/38)
- Go shared-library integration: [elliottech/lighter-go#81](https://github.com/elliottech/lighter-go/pull/81)

## Validation

- `pytest -q` (80 passed)
- strict project `flake8` error checks
- concurrent singleton initialization test
- POSIX/Windows allocator selection tests
- packed-response truncation, trailing-data, count, and native-result-count tests
- legacy binary fallback and negative/overflow nonce tests
